### PR TITLE
feat: add support for custom MSSQL port and Docker environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Git
+.git
+.gitignore
+
+# Virtual Environment
+venv/
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Logs
+*.log
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+ENV/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS specific
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+
+# Environment files
+.env
+*.env
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies including FreeTDS for pymssql
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    freetds-dev \
+    freetds-bin \
+    unixodbc \
+    unixodbc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements
+COPY requirements.txt .
+COPY requirements-dev.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir -r requirements-dev.txt
+
+# Copy project files
+COPY . .
+
+# Run the MCP server
+CMD ["python", "-m", "mssql_mcp_server"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+.PHONY: venv install install-dev test lint format clean run docker-build docker-up docker-down docker-test docker-exec
+
+PYTHON := python3
+VENV := venv
+BIN := $(VENV)/bin
+
+venv:
+	$(PYTHON) -m venv $(VENV)
+
+install: venv
+	$(BIN)/pip install -r requirements.txt
+
+install-dev: install
+	$(BIN)/pip install -r requirements-dev.txt
+
+test: install-dev
+	$(BIN)/pytest -v
+
+lint: install-dev
+	$(BIN)/black --check src tests
+	$(BIN)/isort --check src tests
+	$(BIN)/mypy src tests
+
+format: install-dev
+	$(BIN)/black src tests
+	$(BIN)/isort src tests
+
+clean:
+	rm -rf $(VENV) __pycache__ .pytest_cache .coverage
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type d -name "*.egg-info" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+
+run: install
+	$(BIN)/python -m mssql_mcp_server
+
+# Docker commands
+docker-build:
+	docker-compose build
+
+docker-up:
+	docker-compose up -d
+
+docker-down:
+	docker-compose down
+
+docker-test:
+	docker-compose exec mcp_server pytest -v
+
+docker-exec:
+	docker-compose exec mcp_server bash
+
+# Test MSSQL connection
+test-connection:
+	$(PYTHON) test_connection.py --server $${MSSQL_SERVER:-localhost} --port $${HOST_SQL_PORT:-1434} --user $${MSSQL_USER:-sa} --password $${MSSQL_PASSWORD:-StrongPassword123!} --database $${MSSQL_DATABASE:-master}
+
+# Set environment variables for testing
+test-env:
+	@echo "Export your database credentials before running tests:"
+	@echo "export MSSQL_SERVER=your_server"
+	@echo "export MSSQL_PORT=1433"
+	@echo "export MSSQL_USER=your_username"
+	@echo "export MSSQL_PASSWORD=your_password"
+	@echo "export MSSQL_DATABASE=your_database"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ MSSQL_SERVER=localhost
 MSSQL_USER=your_username
 MSSQL_PASSWORD=your_password
 MSSQL_DATABASE=your_database
+MSSQL_PORT=1433  # Optional, defaults to 1433
 ```
 
 ## Usage
@@ -42,7 +43,7 @@ Add this to your `claude_desktop_config.json`:
     "mssql": {
       "command": "uv",
       "args": [
-        "--directory", 
+        "--directory",
         "path/to/mssql_mcp_server",
         "run",
         "mssql_mcp_server"
@@ -51,7 +52,8 @@ Add this to your `claude_desktop_config.json`:
         "MSSQL_SERVER": "localhost",
         "MSSQL_USER": "your_username",
         "MSSQL_PASSWORD": "your_password",
-        "MSSQL_DATABASE": "your_database"
+        "MSSQL_DATABASE": "your_database",
+        "MSSQL_PORT": "1433"  # Optional, defaults to 1433
       }
     }
   }
@@ -75,16 +77,26 @@ python -m mssql_mcp_server
 git clone https://github.com/RichardHan/mssql_mcp_server.git
 cd mssql_mcp_server
 
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate  # or `venv\Scripts\activate` on Windows
-
-# Install development dependencies
-pip install -r requirements-dev.txt
+# Setup development environment
+make install-dev
 
 # Run tests
-pytest
+make test
+
+# Format code
+make format
+
+# Lint code
+make lint
+
+# Run the server
+make run
+
+# Clean up
+make clean
 ```
+
+For more commands, see the `Makefile`.
 
 ## Security Considerations
 
@@ -104,6 +116,7 @@ This MCP server requires database access to function. For security:
 5. **Regular security reviews** of database access
 
 See [SQL Server Security Configuration Guide](SECURITY.md) for detailed instructions on:
+
 - Creating a restricted SQL Server login
 - Setting appropriate permissions
 - Monitoring database access
@@ -122,3 +135,56 @@ MIT License - see LICENSE file for details.
 3. Commit your changes (`git commit -m 'Add some amazing feature'`)
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
+
+## Docker Testing
+
+This repository includes Docker configuration for easy testing with a SQL Server instance:
+
+```bash
+# Start SQL Server and MCP server containers
+make docker-build
+make docker-up
+
+# Test the connection to the SQL Server
+make test-connection
+
+# Run tests inside the Docker container
+make docker-test
+
+# To tear down the containers
+make docker-down
+```
+
+### Docker Environment Variables
+
+You can customize the Docker configuration by setting environment variables before running `docker-compose`:
+
+```bash
+# Change the host port for SQL Server
+export HOST_SQL_PORT=1435
+# Change the SQL Server password
+export MSSQL_PASSWORD=MyCustomPassword!
+# Start the containers with custom configuration
+make docker-up
+```
+
+Available environment variables:
+
+| Variable         | Default            | Description                           |
+| ---------------- | ------------------ | ------------------------------------- |
+| MSSQL_SERVER     | mssql              | Server hostname (container name)      |
+| MSSQL_PORT       | 1433               | SQL Server port (internal)            |
+| MSSQL_USER       | sa                 | SQL Server username                   |
+| MSSQL_PASSWORD   | StrongPassword123! | SQL Server password                   |
+| MSSQL_DATABASE   | master             | Default database                      |
+| HOST_SQL_PORT    | 1434               | Host port mapped to SQL Server        |
+| HOST_MCP_PORT    | 3000               | Host port mapped to MCP server        |
+| SQL_MEMORY_LIMIT | 2g                 | Memory limit for SQL Server container |
+
+The Docker setup includes:
+
+- A SQL Server 2019 container with a default `sa` user
+- The MCP server container with all dependencies pre-installed
+- Proper networking between the containers
+
+This is useful for development and testing without requiring a local SQL Server installation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+services:
+  # SQL Server
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    platform: linux/amd64
+    environment:
+      - ACCEPT_EULA=Y
+      - MSSQL_SA_PASSWORD=${MSSQL_PASSWORD:-StrongPassword123!}
+    ports:
+      - "${HOST_SQL_PORT:-1434}:1433"
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "${MSSQL_PASSWORD:-StrongPassword123!}" -Q "SELECT 1" || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    volumes:
+      - mssql_data:/var/opt/mssql
+    mem_limit: ${SQL_MEMORY_LIMIT:-2g}
+
+  # MCP Server
+  mcp_server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      mssql:
+        condition: service_healthy
+    environment:
+      - MSSQL_SERVER=${MSSQL_SERVER:-mssql}
+      - MSSQL_PORT=${MSSQL_PORT:-1433}
+      - MSSQL_USER=${MSSQL_USER:-sa}
+      - MSSQL_PASSWORD=${MSSQL_PASSWORD:-StrongPassword123!}
+      - MSSQL_DATABASE=${MSSQL_DATABASE:-master}
+    ports:
+      - "${HOST_MCP_PORT:-3000}:3000"
+    volumes:
+      - .:/app
+
+volumes:
+  mssql_data:

--- a/test_connection.py
+++ b/test_connection.py
@@ -1,25 +1,46 @@
+#!/usr/bin/env python
+import argparse
 import pymssql
+import sys
 
-config = {
-    "server": "{DB Server}}",
-    "user": "{SQL account}}",
-    "password": "{SQL password}",
-    "database": "{DB Name}}"
-}
+def test_connection(server, user, password, database, port):
+    """Test connection to MSSQL database."""
+    try:
+        print(f"Connecting to {server}:{port}/{database} as {user}...")
+        conn = pymssql.connect(
+            server=server,
+            user=user,
+            password=password,
+            database=database,
+            port=int(port)
+        )
+        cursor = conn.cursor()
+        cursor.execute("SELECT @@VERSION")
+        version = cursor.fetchone()[0]
+        conn.close()
+        print(f"Connection successful!")
+        print(f"SQL Server Version: {version}")
+        return True
+    except Exception as e:
+        print(f"Connection failed: {str(e)}")
+        return False
 
-try:
-    print("Attempting to connect to SQL Server...")
-    conn = pymssql.connect(**config)
-    cursor = conn.cursor()
-    print("Connection successful!")
-    
-    print("\nTesting query execution...")
-    cursor.execute("SELECT TOP 1 * FROM INFORMATION_SCHEMA.TABLES")
-    row = cursor.fetchone()
-    print(f"Query result: {row}")
-    
-    cursor.close()
-    conn.close()
-    print("\nConnection test completed successfully!")
-except Exception as e:
-    print(f"Error: {str(e)}")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Test MSSQL connection')
+    parser.add_argument('--server', default='localhost', help='MSSQL server name or IP')
+    parser.add_argument('--user', required=True, help='Username')
+    parser.add_argument('--password', required=True, help='Password')
+    parser.add_argument('--database', required=True, help='Database name')
+    parser.add_argument('--port', default='1433', help='Port number (default: 1433)')
+
+    args = parser.parse_args()
+
+    success = test_connection(
+        args.server,
+        args.user,
+        args.password,
+        args.database,
+        args.port
+    )
+
+    sys.exit(0 if success else 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,11 @@ def mssql_connection():
         connection = pymssql.connect(
             server=os.getenv("MSSQL_SERVER", "localhost"),
             user=os.getenv("MSSQL_USER", "sa"),
-            password=os.getenv("MSSQL_PASSWORD", "testpassword"),
-            database=os.getenv("MSSQL_DATABASE", "test_db")
+            password=os.getenv("MSSQL_PASSWORD", "StrongPassword123!"),
+            database=os.getenv("MSSQL_DATABASE", "master"),
+            port=os.getenv("MSSQL_PORT", "1433")
         )
-        
+
         # Create a test table
         cursor = connection.cursor()
         cursor.execute("""
@@ -25,15 +26,15 @@ def mssql_connection():
             )
         """)
         connection.commit()
-        
+
         yield connection
-        
+
         # Cleanup
         cursor.execute("DROP TABLE IF EXISTS test_table")
         connection.commit()
         cursor.close()
         connection.close()
-            
+
     except pymssql.Error as e:
         pytest.fail(f"Failed to connect to SQL Server: {e}")
 


### PR DESCRIPTION
## Changes

This PR implements the feature requested in issue #8, adding support for custom MSSQL port configuration.

### Changes include:

1. Added `MSSQL_PORT` environment variable support with a default of `1433`
2. Updated configuration functions to include the port parameter
3. Added Docker environment for easier testing and development
4. Created a comprehensive Makefile for common development tasks
5. Updated documentation with port configuration examples

### Testing

Code implementation is correct, but we had issues running the tests due to FreeTDS dependency problems on macOS ARM architecture.

Resolves: #8