### PR TITLE
feat: add structured and file-backed SQL result handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ ehthumbs.db
 # MCP specific
 mcp-workspace/
 
+# Claude local settings
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,3 @@ ehthumbs.db
 # MCP specific
 mcp-workspace/
 
-# Claude local settings
-.claude/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img width="380" height="200" src="https://glama.ai/mcp/servers/29cpe19k30/badge" alt="Microsoft SQL Server MCP server" />
 </a>
 
-A Model Context Protocol (MCP) server for secure SQL Server database access through Claude Desktop.
+A Model Context Protocol (MCP) server for secure SQL Server database access.
 
 ## Features
 
@@ -16,12 +16,14 @@ A Model Context Protocol (MCP) server for secure SQL Server database access thro
 - 🔐 Multiple authentication methods (SQL, Windows, Azure AD)
 - 🏢 LocalDB and Azure SQL support
 - 🔌 Custom port configuration
+- 🧩 Opt-in JSON and standards-compliant CSV query results
+- 📦 Optional file-backed storage and pagination for oversized results
 
 ## Quick Start
 
-### Install with Claude Desktop
+### Install with an MCP client
 
-Add to your `claude_desktop_config.json`:
+Add the server to your MCP client configuration:
 
 ```json
 {
@@ -72,6 +74,34 @@ MSSQL_PORT=1433                 # Custom port (default: 1433)
 MSSQL_ENCRYPT=true              # Force encryption
 ```
 
+## Query Result Formats
+The default remains `legacy`. Set `MSSQL_RESULT_FORMAT` to `json` or `csv`, or
+override one `execute_sql` call with its `result_format` argument. JSON uses
+compact `columns` and `rows` arrays; `NULL` is `null` and Unicode and delimiters
+are preserved. `legacy` remains available for existing clients.
+
+```bash
+MSSQL_RESULT_FORMAT=json        # legacy, json, or csv
+```
+
+### Oversized Results
+File-backed storage is opt-in via `MSSQL_RESULT_OUTPUT_DIR`. Results exceeding the
+inline row or byte threshold are written as complete JSON files; MCP receives
+metadata and preview rows instead of the full result.
+```bash
+MSSQL_RESULT_OUTPUT_DIR=/private/mssql-results
+MSSQL_RESULT_MAX_INLINE_ROWS=200
+MSSQL_RESULT_MAX_INLINE_BYTES=32768
+```
+Set `store_result: true` to force storage. Stored results can be read with
+`get_sql_result` (bounded row pages) or `read_sql_result_chunk` (bounded file chunks).
+## Export Stored Results
+`export-sql-result` validates a complete canonical result and writes compact JSON to stdout.
+Use either `--result-id ID [--result-dir DIR]` or `--results-json PATH`.
+```bash
+export-sql-result --result-id ID --result-dir /private/mssql-results > full-result.json
+```
+
 ## Alternative Installation Methods
 
 ### Using pip
@@ -79,7 +109,7 @@ MSSQL_ENCRYPT=true              # Force encryption
 pip install microsoft_sql_server_mcp
 ```
 
-Then in `claude_desktop_config.json`:
+Then in your MCP client configuration:
 ```json
 {
   "mcpServers": {

--- a/README.md
+++ b/README.md
@@ -88,13 +88,43 @@ MSSQL_RESULT_FORMAT=json        # legacy, json, or csv
 File-backed storage is opt-in via `MSSQL_RESULT_OUTPUT_DIR`. Results exceeding the
 inline row or byte threshold are written as complete JSON files; MCP receives
 metadata and preview rows instead of the full result.
+
 ```bash
 MSSQL_RESULT_OUTPUT_DIR=/private/mssql-results
 MSSQL_RESULT_MAX_INLINE_ROWS=200
 MSSQL_RESULT_MAX_INLINE_BYTES=32768
 ```
+
 Set `store_result: true` to force storage. Stored results can be read with
 `get_sql_result` (bounded row pages) or `read_sql_result_chunk` (bounded file chunks).
+
+Queries are still fetched and serialized in full in server memory before the
+storage decision. This provides bounded MCP responses and prevents oversized
+payloads from entering model context; it is not streaming query processing.
+
+#### Advanced result limits
+
+These settings apply when `MSSQL_RESULT_OUTPUT_DIR` is configured. Byte values
+are UTF-8 sizes; `0` disables a limit where noted.
+
+| Environment variable | Default | Purpose |
+| --- | ---: | --- |
+| `MSSQL_RESULT_PREVIEW_ROWS` | `5` | Maximum preview rows in a stored-result summary. |
+| `MSSQL_RESULT_PREVIEW_BYTES` | `4096` | Preview byte limit; `0` disables it. |
+| `MSSQL_RESULT_DEFAULT_PAGE_ROWS` | `100` | Default rows returned by `get_sql_result`. |
+| `MSSQL_RESULT_MAX_PAGE_ROWS` | `1000` | Maximum requested rows per page. |
+| `MSSQL_RESULT_MAX_PAGE_BYTES` | `32768` | Serialized page limit; `0` disables it. |
+| `MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES` | `67108864` | Larger files must use chunk reads; `0` disables the guard. |
+| `MSSQL_RESULT_MAX_CHUNK_BYTES` | `16384` | Maximum bytes returned by one chunk read. |
+| `MSSQL_RESULT_TTL_SECONDS` | `86400` | Result lifetime; `0` disables expiry. |
+| `MSSQL_RESULT_MAX_FILE_BYTES` | `1073741824` | Maximum single result file; `0` disables it. |
+| `MSSQL_RESULT_MAX_STORE_BYTES` | `1073741824` | Total store quota; oldest results are evicted, and `0` disables it. |
+| `MSSQL_RESULT_INCLUDE_PATH` | `false` | Return `result_path`; enable only for clients sharing the server filesystem. |
+
+Stored summaries always return `result_id`. Reading every page or chunk through
+MCP can still fill model context; use the export CLI or the opt-in local path for
+bulk access.
+
 ## Export Stored Results
 `export-sql-result` validates a complete canonical result and writes compact JSON to stdout.
 Use either `--result-id ID [--result-dir DIR]` or `--results-json PATH`.

--- a/benchmarks/measure_result_context.py
+++ b/benchmarks/measure_result_context.py
@@ -1,0 +1,96 @@
+"""Measure context-size savings from structured and stored SQL results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from mssql_mcp_server.result_export import load_result_file
+from mssql_mcp_server.serialization import serialize_json, serialize_legacy
+
+
+def _measurement(text: str, bytes_per_token: float) -> dict[str, int]:
+    byte_count = len(text.encode("utf-8"))
+    return {
+        "utf8_bytes": byte_count,
+        "estimated_tokens": math.ceil(byte_count / bytes_per_token),
+    }
+
+
+def measure_context(
+    envelope: dict[str, Any],
+    *,
+    summary: dict[str, Any] | None = None,
+    bytes_per_token: float = 4.0,
+) -> dict[str, Any]:
+    """Compare legacy, inline JSON, and optional stored-summary sizes."""
+    if bytes_per_token <= 0:
+        raise ValueError("bytes_per_token must be greater than zero")
+    legacy_text = serialize_legacy(envelope["columns"], envelope["rows"])
+    json_text = serialize_json(envelope)
+    metrics: dict[str, Any] = {
+        "token_estimate": {
+            "method": "utf8_bytes_divided_by_bytes_per_token",
+            "bytes_per_token": bytes_per_token,
+        },
+        "legacy_inline": _measurement(legacy_text, bytes_per_token),
+        "json_inline": _measurement(json_text, bytes_per_token),
+    }
+    if summary is not None:
+        summary_text = serialize_json(summary)
+        summary_metrics = _measurement(summary_text, bytes_per_token)
+        metrics["stored_summary"] = summary_metrics
+        for baseline in ("legacy_inline", "json_inline"):
+            baseline_bytes = metrics[baseline]["utf8_bytes"]
+            saved_bytes = baseline_bytes - summary_metrics["utf8_bytes"]
+            metrics[f"savings_vs_{baseline}"] = {
+                "utf8_bytes": saved_bytes,
+                "estimated_tokens": metrics[baseline]["estimated_tokens"]
+                - summary_metrics["estimated_tokens"],
+                "percent": (
+                    round(saved_bytes / baseline_bytes * 100, 2)
+                    if baseline_bytes
+                    else 0.0
+                ),
+            }
+    return metrics
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Measure before/after SQL result context size"
+    )
+    parser.add_argument("--results-json", required=True, type=Path)
+    parser.add_argument("--summary-json", type=Path)
+    parser.add_argument("--bytes-per-token", type=float, default=4.0)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    envelope = load_result_file(args.results_json)
+    summary = None
+    if args.summary_json is not None:
+        summary = json.loads(args.summary_json.read_text(encoding="utf-8"))
+        if not isinstance(summary, dict):
+            raise ValueError("Summary JSON must contain an object")
+    print(
+        json.dumps(
+            measure_context(
+                envelope,
+                summary=summary,
+                bytes_per_token=args.bytes_per_token,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ mssql_mcp_server = "mssql_mcp_server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mssql_mcp_server"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["BLE001", "E722", "S110", "SIM117"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 mssql_mcp_server = "mssql_mcp_server:main"
+export-sql-result = "mssql_mcp_server.result_export:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mssql_mcp_server"]

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """Comprehensive test runner for MSSQL MCP Server."""
 
-import sys
-import subprocess
 import argparse
-from pathlib import Path
+import subprocess
+import sys
+
 
 def run_command(cmd, description):
     """Run a command and handle output."""
@@ -13,7 +13,7 @@ def run_command(cmd, description):
     print(f"Command: {' '.join(cmd)}")
     print('='*60)
     
-    result = subprocess.run(cmd, capture_output=False)
+    result = subprocess.run(cmd, capture_output=False, check=False)
     if result.returncode != 0:
         print(f"❌ {description} failed with return code {result.returncode}")
         return False
@@ -57,7 +57,9 @@ def main():
     if args.suite in ['all', 'unit']:
         # Unit tests
         print("\n🧪 Running unit tests...")
-        cmd = pytest_cmd + ['tests/test_config.py', 'tests/test_server.py']
+        cmd = pytest_cmd + ['tests/test_config.py', 'tests/test_server.py',
+                            'tests/test_serialization.py', 'tests/test_result_store.py',
+                            'tests/test_result_export.py', 'tests/test_context_benchmark.py']
         if not run_command(cmd, "Unit tests"):
             success = False
     
@@ -80,7 +82,8 @@ def main():
     if args.suite in ['all', 'integration']:
         # Integration tests
         print("\n🔗 Running integration tests...")
-        cmd = pytest_cmd + ['tests/test_integration.py', 'tests/test_error_handling.py']
+        cmd = pytest_cmd + ['tests/test_integration.py', 'tests/test_error_handling.py',
+                            'tests/test_query_results.py']
         if not run_command(cmd, "Integration tests"):
             success = False
     

--- a/src/mssql_mcp_server/__init__.py
+++ b/src/mssql_mcp_server/__init__.py
@@ -1,5 +1,7 @@
-from . import server
 import asyncio
+
+from . import server
+
 
 def main():
    """Main entry point for the package."""

--- a/src/mssql_mcp_server/result_export.py
+++ b/src/mssql_mcp_server/result_export.py
@@ -1,0 +1,88 @@
+"""Export a complete canonical SQL result envelope to standard output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .result_store import ResultStore, ResultStoreConfig, validate_result_envelope
+from .serialization import serialize_json
+
+CANONICAL_RESULT_KEYS = frozenset({"columns", "rows", "row_count", "truncated"})
+
+
+def validate_complete_result_envelope(envelope: Any) -> dict[str, Any]:
+    """Validate that a value is a complete result rather than a summary or page."""
+    validated = validate_result_envelope(envelope)
+    if set(validated) != CANONICAL_RESULT_KEYS:
+        raise ValueError("Result JSON is not a complete canonical result envelope")
+    return validated
+
+
+def load_result_file(path: Path) -> dict[str, Any]:
+    """Load and validate a complete canonical result envelope from a JSON file."""
+
+    def reject_nonstandard_constant(value: str) -> None:
+        raise ValueError(f"Non-standard JSON constant is not allowed: {value}")
+
+    try:
+        envelope = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=reject_nonstandard_constant,
+        )
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise ValueError(f"Unable to read result JSON '{path}': {exc}") from exc
+    return validate_complete_result_envelope(envelope)
+
+
+def load_stored_result(
+    result_id: str, result_dir: Path | None = None
+) -> dict[str, Any]:
+    """Load a stored result by ID using configured safety and expiry settings."""
+    config = ResultStoreConfig.from_env(output_dir_override=result_dir)
+    if config.output_dir is None:
+        raise ValueError(
+            "--result-dir or MSSQL_RESULT_OUTPUT_DIR is required with --result-id"
+        )
+    if not config.output_dir.is_dir():
+        raise ValueError(f"Result directory does not exist: {config.output_dir}")
+    store = ResultStore(config)
+    return validate_complete_result_envelope(store.load(result_id))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser for canonical result export."""
+    parser = argparse.ArgumentParser(
+        description="Export a complete canonical SQL result as compact JSON"
+    )
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument("--result-id")
+    source_group.add_argument("--results-json", type=Path)
+    parser.add_argument(
+        "--result-dir",
+        type=Path,
+        help="Override MSSQL_RESULT_OUTPUT_DIR when --result-id is used",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Load one canonical result and write compact JSON to standard output."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.results_json is not None:
+        if args.result_dir is not None:
+            parser.error("--result-dir requires --result-id")
+        envelope = load_result_file(args.results_json)
+    else:
+        envelope = load_stored_result(args.result_id, args.result_dir)
+
+    print(serialize_json(envelope))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mssql_mcp_server/result_store.py
+++ b/src/mssql_mcp_server/result_store.py
@@ -1,0 +1,546 @@
+"""Bounded, file-backed storage for oversized SQL result sets."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .serialization import serialize_json
+
+RESULT_ID_PATTERN = re.compile(r"^[0-9a-f]{32}$")
+RESULT_FILE_PATTERN = re.compile(r"^[0-9a-f]{32}\.json$")
+_STORE_LOCK = threading.RLock()
+
+
+def validate_result_envelope(envelope: Any) -> dict[str, Any]:
+    """Validate the canonical result envelope before downstream use."""
+    required_keys = {"columns", "rows", "row_count", "truncated"}
+    if not isinstance(envelope, dict) or not required_keys.issubset(envelope):
+        raise ValueError("Result JSON is not a canonical result envelope")
+    columns = envelope["columns"]
+    rows = envelope["rows"]
+    if not isinstance(columns, list) or not all(
+        isinstance(column, str) for column in columns
+    ):
+        raise ValueError("Result columns must be an array of strings")
+    if not isinstance(rows, list) or not all(isinstance(row, list) for row in rows):
+        raise ValueError("Result rows must be an array of arrays")
+    if any(len(row) != len(columns) for row in rows):
+        raise ValueError("Every result row must have the same width as columns")
+    if (
+        isinstance(envelope["row_count"], bool)
+        or not isinstance(envelope["row_count"], int)
+        or envelope["row_count"] != len(rows)
+    ):
+        raise ValueError("Result row_count does not match rows")
+    if not isinstance(envelope["truncated"], bool):
+        raise ValueError("Result truncated must be a boolean")  # noqa: TRY004
+    return envelope
+
+
+def _env_non_negative_int(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a non-negative integer") from exc
+    if value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _validate_int(value: Any, name: str, *, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")  # noqa: TRY004
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
+
+
+@dataclass(frozen=True)
+class ResultStoreConfig:
+    """Configuration for automatic result persistence and bounded retrieval."""
+
+    output_dir: Path | None = None
+    max_inline_rows: int = 200
+    max_inline_bytes: int = 32 * 1024
+    preview_rows: int = 5
+    preview_bytes: int = 4 * 1024
+    default_page_rows: int = 100
+    max_page_rows: int = 1000
+    max_page_bytes: int = 32 * 1024
+    max_page_source_bytes: int = 64 * 1024 * 1024
+    max_chunk_bytes: int = 16 * 1024
+    ttl_seconds: int = 24 * 60 * 60
+    max_store_bytes: int = 1024 * 1024 * 1024
+
+    def __post_init__(self) -> None:
+        if isinstance(self.max_page_bytes, bool) or not isinstance(
+            self.max_page_bytes, int
+        ):
+            raise ValueError(  # noqa: TRY004
+                "MSSQL_RESULT_MAX_PAGE_BYTES must be an integer"
+            )
+        if self.max_page_bytes < 0 or 0 < self.max_page_bytes < 512:
+            raise ValueError("MSSQL_RESULT_MAX_PAGE_BYTES must be 0 or at least 512")
+        if isinstance(self.max_page_source_bytes, bool) or not isinstance(
+            self.max_page_source_bytes, int
+        ):
+            raise ValueError(  # noqa: TRY004
+                "MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES must be an integer"
+            )
+        if self.max_page_source_bytes < 0:
+            raise ValueError(
+                "MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES must be a non-negative integer"
+            )
+
+    @classmethod
+    def from_env(cls, *, output_dir_override: Path | None = None) -> ResultStoreConfig:
+        raw_output_dir = (
+            str(output_dir_override)
+            if output_dir_override is not None
+            else os.getenv("MSSQL_RESULT_OUTPUT_DIR")
+        )
+        if not raw_output_dir:
+            return cls()
+
+        output_dir = Path(raw_output_dir).expanduser()
+        if not output_dir.is_absolute():
+            raise ValueError("MSSQL_RESULT_OUTPUT_DIR must be an absolute path")
+
+        config = cls(
+            output_dir=output_dir.resolve(strict=False),
+            max_inline_rows=_env_non_negative_int("MSSQL_RESULT_MAX_INLINE_ROWS", 200),
+            max_inline_bytes=_env_non_negative_int(
+                "MSSQL_RESULT_MAX_INLINE_BYTES", 32 * 1024
+            ),
+            preview_rows=_env_non_negative_int("MSSQL_RESULT_PREVIEW_ROWS", 5),
+            preview_bytes=_env_non_negative_int("MSSQL_RESULT_PREVIEW_BYTES", 4 * 1024),
+            default_page_rows=_env_non_negative_int(
+                "MSSQL_RESULT_DEFAULT_PAGE_ROWS", 100
+            ),
+            max_page_rows=_env_non_negative_int("MSSQL_RESULT_MAX_PAGE_ROWS", 1000),
+            max_page_bytes=_env_non_negative_int(
+                "MSSQL_RESULT_MAX_PAGE_BYTES", 32 * 1024
+            ),
+            max_page_source_bytes=_env_non_negative_int(
+                "MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES", 64 * 1024 * 1024
+            ),
+            max_chunk_bytes=_env_non_negative_int(
+                "MSSQL_RESULT_MAX_CHUNK_BYTES", 16 * 1024
+            ),
+            ttl_seconds=_env_non_negative_int("MSSQL_RESULT_TTL_SECONDS", 24 * 60 * 60),
+            max_store_bytes=_env_non_negative_int(
+                "MSSQL_RESULT_MAX_STORE_BYTES", 1024 * 1024 * 1024
+            ),
+        )
+        if config.max_page_rows < 1:
+            raise ValueError("MSSQL_RESULT_MAX_PAGE_ROWS must be at least 1")
+        if not 1 <= config.default_page_rows <= config.max_page_rows:
+            raise ValueError(
+                "MSSQL_RESULT_DEFAULT_PAGE_ROWS must be between 1 and "
+                "MSSQL_RESULT_MAX_PAGE_ROWS"
+            )
+        if config.max_chunk_bytes < 1:
+            raise ValueError("MSSQL_RESULT_MAX_CHUNK_BYTES must be at least 1")
+        return config
+
+    @property
+    def enabled(self) -> bool:
+        return self.output_dir is not None
+
+
+class ResultStore:
+    """Persist and retrieve canonical JSON result envelopes."""
+
+    def __init__(self, config: ResultStoreConfig):
+        self.config = config
+        self.root: Path | None = None
+        if config.output_dir is not None:
+            config.output_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            root = config.output_dir.resolve(strict=True)
+            if not root.is_dir():
+                raise ValueError("MSSQL_RESULT_OUTPUT_DIR must be a directory")
+            self.root = root
+
+    @classmethod
+    def from_env(cls, *, output_dir_override: Path | None = None) -> ResultStore:
+        return cls(ResultStoreConfig.from_env(output_dir_override=output_dir_override))
+
+    @property
+    def enabled(self) -> bool:
+        return self.root is not None
+
+    def should_store(
+        self, payload_bytes: bytes, row_count: int, *, force: bool
+    ) -> bool:
+        if force:
+            if not self.enabled:
+                raise ValueError(
+                    "store_result requires MSSQL_RESULT_OUTPUT_DIR to be configured"
+                )
+            return True
+        if not self.enabled:
+            return False
+        row_limit = self.config.max_inline_rows
+        byte_limit = self.config.max_inline_bytes
+        return (row_limit > 0 and row_count > row_limit) or (
+            byte_limit > 0 and len(payload_bytes) > byte_limit
+        )
+
+    def store(self, envelope: dict[str, Any], payload_bytes: bytes) -> dict[str, Any]:
+        root = self._require_root()
+        if (
+            self.config.max_store_bytes > 0
+            and len(payload_bytes) > self.config.max_store_bytes
+        ):
+            raise ValueError("Serialized result exceeds MSSQL_RESULT_MAX_STORE_BYTES")
+
+        result_id = uuid4().hex
+        final_path = root / f"{result_id}.json"
+        temp_path = root / f".{result_id}.{uuid4().hex}.tmp"
+
+        with _STORE_LOCK:
+            self._make_room(len(payload_bytes))
+            try:
+                with temp_path.open("xb") as result_file:
+                    try:
+                        os.chmod(temp_path, 0o600)
+                    except OSError:
+                        pass
+                    result_file.write(payload_bytes)
+                    result_file.flush()
+                    os.fsync(result_file.fileno())
+                os.replace(temp_path, final_path)
+            finally:
+                if temp_path.exists():
+                    temp_path.unlink()
+
+        stat = final_path.stat()
+        expires_at = (
+            int(stat.st_mtime + self.config.ttl_seconds)
+            if self.config.ttl_seconds > 0
+            else None
+        )
+        return {
+            "columns": envelope["columns"],
+            "row_count": envelope["row_count"],
+            "stored": True,
+            "result_id": result_id,
+            "result_path": str(final_path),
+            "byte_count": len(payload_bytes),
+            "sha256": hashlib.sha256(payload_bytes).hexdigest(),
+            "preview_rows": self._preview(envelope["rows"]),
+            "truncated": envelope["truncated"],
+            "expires_at": expires_at,
+        }
+
+    def read_page(
+        self, result_id: str, *, offset: Any = 0, limit: Any = None
+    ) -> dict[str, Any]:
+        limit = self.config.default_page_rows if limit is None else limit
+        offset = _validate_int(offset, "offset", minimum=0, maximum=2**63 - 1)
+        limit = _validate_int(
+            limit, "limit", minimum=1, maximum=self.config.max_page_rows
+        )
+        source_bytes = self._result_path(result_id).stat().st_size
+        max_page_source_bytes = self.config.max_page_source_bytes
+        if max_page_source_bytes > 0 and source_bytes > max_page_source_bytes:
+            return self._chunk_required_descriptor(
+                result_id,
+                offset,
+                reason="result_exceeds_page_source_limit",
+                source_bytes=source_bytes,
+                max_page_source_bytes=max_page_source_bytes,
+            )
+
+        envelope = self._load_envelope(result_id)
+        total_row_count = envelope["row_count"]
+        if offset > total_row_count:
+            raise ValueError("offset must not exceed total_row_count")
+        available_rows = envelope["rows"][offset : offset + limit]
+
+        page_rows: list[list[Any]] = []
+        page_rows_bytes = 0
+        columns_bytes = serialize_json(envelope["columns"]).encode("utf-8")
+        result_id_bytes = serialize_json(result_id).encode("utf-8")
+        max_page_bytes = self.config.max_page_bytes
+
+        if (
+            max_page_bytes > 0
+            and self._page_serialized_size(
+                envelope,
+                offset=offset,
+                returned_rows=0,
+                rows_bytes=0,
+                columns_bytes=columns_bytes,
+                result_id_bytes=result_id_bytes,
+            )
+            > max_page_bytes
+        ):
+            return self._chunk_required_descriptor(
+                result_id,
+                offset,
+                reason="columns_exceed_page_byte_limit",
+                envelope=envelope,
+            )
+
+        for row in available_rows:
+            row_bytes = len(serialize_json(row).encode("utf-8"))
+            candidate_row_count = len(page_rows) + 1
+            candidate_rows_bytes = page_rows_bytes + row_bytes
+            if page_rows:
+                candidate_rows_bytes += 1  # The comma between compact JSON rows.
+            if (
+                max_page_bytes > 0
+                and self._page_serialized_size(
+                    envelope,
+                    offset=offset,
+                    returned_rows=candidate_row_count,
+                    rows_bytes=candidate_rows_bytes,
+                    columns_bytes=columns_bytes,
+                    result_id_bytes=result_id_bytes,
+                )
+                > max_page_bytes
+            ):
+                if not page_rows:
+                    return self._chunk_required_descriptor(
+                        result_id,
+                        offset,
+                        reason="row_exceeds_page_byte_limit",
+                        envelope=envelope,
+                        row_index=offset,
+                    )
+                break
+            page_rows.append(row)
+            page_rows_bytes = candidate_rows_bytes
+
+        return self._page_envelope(envelope, result_id, offset, page_rows)
+
+    def read_chunk(
+        self, result_id: str, *, offset_bytes: Any = 0, max_bytes: Any = None
+    ) -> dict[str, Any]:
+        max_bytes = self.config.max_chunk_bytes if max_bytes is None else max_bytes
+        offset_bytes = _validate_int(
+            offset_bytes, "offset_bytes", minimum=0, maximum=2**63 - 1
+        )
+        max_bytes = _validate_int(
+            max_bytes,
+            "max_bytes",
+            minimum=1,
+            maximum=self.config.max_chunk_bytes,
+        )
+        with _STORE_LOCK:
+            path = self._result_path(result_id)
+            with path.open("rb", buffering=0) as result_file:
+                total_bytes = os.fstat(result_file.fileno()).st_size
+                if offset_bytes > total_bytes:
+                    raise ValueError("offset_bytes must not exceed total_bytes")
+                result_file.seek(offset_bytes)
+                chunk = result_file.read(max_bytes)
+        next_offset = offset_bytes + len(chunk)
+        return {
+            "result_id": result_id,
+            "offset_bytes": offset_bytes,
+            "returned_bytes": len(chunk),
+            "next_offset": next_offset,
+            "total_bytes": total_bytes,
+            "eof": next_offset >= total_bytes,
+            "data_base64": base64.b64encode(chunk).decode("ascii"),
+        }
+
+    def load(self, result_id: str) -> dict[str, Any]:
+        """Load and validate a complete stored result for machine consumers."""
+        return self._load_envelope(result_id)
+
+    def _page_envelope(
+        self,
+        envelope: dict[str, Any],
+        result_id: str,
+        offset: int,
+        rows: list[list[Any]],
+    ) -> dict[str, Any]:
+        next_offset = offset + len(rows)
+        return {
+            "columns": envelope["columns"],
+            "rows": rows,
+            "total_row_count": envelope["row_count"],
+            "result_id": result_id,
+            "offset": offset,
+            "returned_rows": len(rows),
+            "next_offset": next_offset,
+            "has_more": next_offset < envelope["row_count"],
+            "truncated": envelope["truncated"],
+        }
+
+    def _page_serialized_size(
+        self,
+        envelope: dict[str, Any],
+        *,
+        offset: int,
+        returned_rows: int,
+        rows_bytes: int,
+        columns_bytes: bytes,
+        result_id_bytes: bytes,
+    ) -> int:
+        """Return the exact compact UTF-8 size without re-serializing page rows."""
+        total_row_count = envelope["row_count"]
+        next_offset = offset + returned_rows
+        has_more = next_offset < total_row_count
+        truncated = envelope["truncated"]
+        return sum(
+            (
+                len(b'{"columns":'),
+                len(columns_bytes),
+                len(b',"rows":['),
+                rows_bytes,
+                len(b'],"total_row_count":'),
+                len(str(total_row_count)),
+                len(b',"result_id":'),
+                len(result_id_bytes),
+                len(b',"offset":'),
+                len(str(offset)),
+                len(b',"returned_rows":'),
+                len(str(returned_rows)),
+                len(b',"next_offset":'),
+                len(str(next_offset)),
+                len(b',"has_more":'),
+                len(b"true" if has_more else b"false"),
+                len(b',"truncated":'),
+                len(b"true" if truncated else b"false"),
+                len(b"}"),
+            )
+        )
+
+    def _chunk_required_descriptor(
+        self,
+        result_id: str,
+        offset: int,
+        *,
+        reason: str,
+        envelope: dict[str, Any] | None = None,
+        row_index: int | None = None,
+        source_bytes: int | None = None,
+        max_page_source_bytes: int | None = None,
+    ) -> dict[str, Any]:
+        """Return a terminal, byte-bounded pointer to chunk retrieval."""
+        descriptor = {
+            "result_id": result_id,
+            "offset": offset,
+            "returned_rows": 0,
+            "chunk_required": True,
+            "reason": reason,
+        }
+        if envelope is not None:
+            descriptor["total_row_count"] = envelope["row_count"]
+            descriptor["truncated"] = envelope["truncated"]
+        if row_index is not None:
+            descriptor["row_index"] = row_index
+        if source_bytes is not None:
+            descriptor["source_bytes"] = source_bytes
+        if max_page_source_bytes is not None:
+            descriptor["max_page_source_bytes"] = max_page_source_bytes
+
+        max_page_bytes = self.config.max_page_bytes
+        if (
+            max_page_bytes > 0
+            and len(serialize_json(descriptor).encode("utf-8")) > max_page_bytes
+        ):
+            raise RuntimeError(
+                "MSSQL_RESULT_MAX_PAGE_BYTES is too small for a chunk descriptor"
+            )
+        return descriptor
+
+    def _preview(self, rows: list[list[Any]]) -> list[list[Any]]:
+        preview: list[list[Any]] = []
+        for row in rows[: self.config.preview_rows]:
+            candidate = [*preview, row]
+            if (
+                self.config.preview_bytes > 0
+                and len(serialize_json(candidate).encode("utf-8"))
+                > self.config.preview_bytes
+            ):
+                break
+            preview.append(row)
+        return preview
+
+    def _load_envelope(self, result_id: str) -> dict[str, Any]:
+        payload = self._read_payload(result_id)
+        try:
+            envelope = json.loads(payload)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Stored result '{result_id}' is corrupt") from exc
+        try:
+            return validate_result_envelope(envelope)
+        except ValueError as exc:
+            raise RuntimeError(f"Stored result '{result_id}' is corrupt") from exc
+
+    def _read_payload(self, result_id: str) -> bytes:
+        path = self._result_path(result_id)
+        with _STORE_LOCK:
+            return path.read_bytes()
+
+    def _result_path(self, result_id: str) -> Path:
+        root = self._require_root()
+        if not isinstance(result_id, str) or not RESULT_ID_PATTERN.fullmatch(result_id):
+            raise ValueError("result_id must be 32 lowercase hexadecimal characters")
+        candidate = root / f"{result_id}.json"
+        if candidate.is_symlink():
+            raise ValueError("Stored result symlinks are not allowed")
+        try:
+            resolved = candidate.resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Unknown result_id: {result_id}") from exc
+        if not resolved.is_relative_to(root) or not resolved.is_file():
+            raise ValueError("Stored result path is outside the configured directory")
+        if (
+            self.config.ttl_seconds > 0
+            and time.time() - resolved.stat().st_mtime > self.config.ttl_seconds
+        ):
+            raise FileNotFoundError(f"Result has expired: {result_id}")
+        return resolved
+
+    def _make_room(self, incoming_bytes: int) -> None:
+        root = self._require_root()
+        now = time.time()
+        result_files = []
+        for path in root.iterdir():
+            if path.is_symlink() or not RESULT_FILE_PATTERN.fullmatch(path.name):
+                continue
+            try:
+                stat = path.stat()
+            except FileNotFoundError:
+                continue
+            if (
+                self.config.ttl_seconds > 0
+                and now - stat.st_mtime > self.config.ttl_seconds
+            ):
+                path.unlink(missing_ok=True)
+                continue
+            result_files.append((stat.st_mtime, stat.st_size, path))
+
+        quota = self.config.max_store_bytes
+        if quota <= 0:
+            return
+        current_bytes = sum(size for _, size, _ in result_files)
+        for _, size, path in sorted(result_files):
+            if current_bytes + incoming_bytes <= quota:
+                break
+            path.unlink(missing_ok=True)
+            current_bytes -= size
+
+    def _require_root(self) -> Path:
+        if self.root is None:
+            raise ValueError("MSSQL_RESULT_OUTPUT_DIR is not configured")
+        return self.root

--- a/src/mssql_mcp_server/result_store.py
+++ b/src/mssql_mcp_server/result_store.py
@@ -60,6 +60,18 @@ def _env_non_negative_int(name: str, default: int) -> int:
     return value
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    normalized = raw_value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise ValueError(f"{name} must be true or false")
+
+
 def _validate_int(value: Any, name: str, *, minimum: int, maximum: int) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"{name} must be an integer")  # noqa: TRY004
@@ -83,7 +95,9 @@ class ResultStoreConfig:
     max_page_source_bytes: int = 64 * 1024 * 1024
     max_chunk_bytes: int = 16 * 1024
     ttl_seconds: int = 24 * 60 * 60
+    max_file_bytes: int = 1024 * 1024 * 1024
     max_store_bytes: int = 1024 * 1024 * 1024
+    include_path: bool = False
 
     def __post_init__(self) -> None:
         if isinstance(self.max_page_bytes, bool) or not isinstance(
@@ -141,9 +155,13 @@ class ResultStoreConfig:
                 "MSSQL_RESULT_MAX_CHUNK_BYTES", 16 * 1024
             ),
             ttl_seconds=_env_non_negative_int("MSSQL_RESULT_TTL_SECONDS", 24 * 60 * 60),
+            max_file_bytes=_env_non_negative_int(
+                "MSSQL_RESULT_MAX_FILE_BYTES", 1024 * 1024 * 1024
+            ),
             max_store_bytes=_env_non_negative_int(
                 "MSSQL_RESULT_MAX_STORE_BYTES", 1024 * 1024 * 1024
             ),
+            include_path=_env_bool("MSSQL_RESULT_INCLUDE_PATH", False),
         )
         if config.max_page_rows < 1:
             raise ValueError("MSSQL_RESULT_MAX_PAGE_ROWS must be at least 1")
@@ -202,10 +220,17 @@ class ResultStore:
     def store(self, envelope: dict[str, Any], payload_bytes: bytes) -> dict[str, Any]:
         root = self._require_root()
         if (
+            self.config.max_file_bytes > 0
+            and len(payload_bytes) > self.config.max_file_bytes
+        ):
+            raise ValueError("Serialized result exceeds MSSQL_RESULT_MAX_FILE_BYTES")
+        if (
             self.config.max_store_bytes > 0
             and len(payload_bytes) > self.config.max_store_bytes
         ):
-            raise ValueError("Serialized result exceeds MSSQL_RESULT_MAX_STORE_BYTES")
+            raise ValueError(
+                "Serialized result cannot fit within MSSQL_RESULT_MAX_STORE_BYTES"
+            )
 
         result_id = uuid4().hex
         final_path = root / f"{result_id}.json"
@@ -233,18 +258,20 @@ class ResultStore:
             if self.config.ttl_seconds > 0
             else None
         )
-        return {
+        summary = {
             "columns": envelope["columns"],
             "row_count": envelope["row_count"],
             "stored": True,
             "result_id": result_id,
-            "result_path": str(final_path),
             "byte_count": len(payload_bytes),
             "sha256": hashlib.sha256(payload_bytes).hexdigest(),
             "preview_rows": self._preview(envelope["rows"]),
             "truncated": envelope["truncated"],
             "expires_at": expires_at,
         }
+        if self.config.include_path:
+            summary["result_path"] = str(final_path)
+        return summary
 
     def read_page(
         self, result_id: str, *, offset: Any = 0, limit: Any = None

--- a/src/mssql_mcp_server/serialization.py
+++ b/src/mssql_mcp_server/serialization.py
@@ -1,0 +1,116 @@
+"""Serialization helpers for SQL Server result sets."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import json
+import math
+from collections.abc import Iterable, Sequence
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
+from io import StringIO
+from typing import Any
+from uuid import UUID
+
+
+class ResultFormat(str, Enum):
+    """Supported wire formats for tabular query results."""
+
+    LEGACY = "legacy"
+    JSON = "json"
+    CSV = "csv"
+
+    @classmethod
+    def parse(cls, value: str | None, *, default: str = "legacy") -> ResultFormat:
+        candidate = (default if value is None else value).strip().lower()
+        try:
+            return cls(candidate)
+        except ValueError as exc:
+            supported = ", ".join(item.value for item in cls)
+            raise ValueError(
+                f"Unsupported result format '{candidate}'. Expected one of: {supported}"
+            ) from exc
+
+
+def normalize_value(value: Any) -> Any:
+    """Convert database values into stable JSON-compatible values."""
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        encoded = base64.b64encode(bytes(value)).decode("ascii")
+        return f"base64:{encoded}"
+    if isinstance(value, Enum):
+        return normalize_value(value.value)
+    return str(value)
+
+
+def build_result(
+    columns: Sequence[str], rows: Iterable[Sequence[Any]], *, truncated: bool = False
+) -> dict[str, Any]:
+    """Build the compact column-array/row-array result envelope."""
+    normalized_rows = [[normalize_value(value) for value in row] for row in rows]
+    return {
+        "columns": list(columns),
+        "rows": normalized_rows,
+        "row_count": len(normalized_rows),
+        "truncated": truncated,
+    }
+
+
+def serialize_json(result: Any) -> str:
+    """Serialize a result envelope as compact, lossless Unicode JSON."""
+    return json.dumps(
+        result,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def serialize_csv(columns: Sequence[str], rows: Iterable[Sequence[Any]]) -> str:
+    """Serialize rows as RFC 4180-style CSV using Python's csv module."""
+    output = StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow(columns)
+    writer.writerows(
+        ["" if value is None else normalize_value(value) for value in row]
+        for row in rows
+    )
+    return output.getvalue().rstrip("\n")
+
+
+def serialize_legacy(columns: Sequence[str], rows: Iterable[Sequence[Any]]) -> str:
+    """Reproduce the original delimiter-joined output for compatibility."""
+    result_rows = [",".join(map(str, row)) for row in rows]
+    return "\n".join([",".join(columns), *result_rows])
+
+
+def serialize_result(
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+    result_format: ResultFormat,
+) -> str:
+    """Serialize a materialized result set in the requested wire format."""
+    materialized_rows = list(rows)
+    if result_format is ResultFormat.LEGACY:
+        return serialize_legacy(columns, materialized_rows)
+    return serialize_envelope(build_result(columns, materialized_rows), result_format)
+
+
+def serialize_envelope(result: dict[str, Any], result_format: ResultFormat) -> str:
+    """Serialize an existing result envelope in the requested wire format."""
+    if result_format is ResultFormat.LEGACY:
+        return serialize_legacy(result["columns"], result["rows"])
+    if result_format is ResultFormat.CSV:
+        return serialize_csv(result["columns"], result["rows"])
+    return serialize_json(result)

--- a/src/mssql_mcp_server/server.py
+++ b/src/mssql_mcp_server/server.py
@@ -2,10 +2,24 @@ import asyncio
 import logging
 import os
 import re
+
 import pymssql
 from mcp.server import Server
-from mcp.types import Resource, Tool, TextContent
+from mcp.types import Resource, TextContent, Tool
 from pydantic import AnyUrl
+
+from .result_store import ResultStore
+from .serialization import (
+    ResultFormat,
+    build_result,
+    serialize_csv,
+    serialize_envelope,
+    serialize_json,
+    serialize_legacy,
+)
+
+GET_RESULT_TOOL = "get_sql_result"
+READ_RESULT_CHUNK_TOOL = "read_sql_result_chunk"
 
 # Configure logging
 logging.basicConfig(
@@ -59,6 +73,7 @@ def get_db_config():
             config["port"] = int(port)
         except ValueError:
             logger.warning(f"Invalid MSSQL_PORT value: {port}. Using default port.")
+            config["port"] = "1433"
     
     # Encryption settings for Azure SQL (Issue #11)
     # Check if we're connecting to Azure SQL
@@ -101,6 +116,62 @@ def get_command():
     """Get the command to execute SQL queries."""
     return os.getenv("MSSQL_COMMAND", "execute_sql")
 
+def get_result_format(requested_format: str | None = None) -> ResultFormat:
+    """Resolve a request override or the configured default result format."""
+    configured_format = os.getenv("MSSQL_RESULT_FORMAT", ResultFormat.LEGACY.value)
+    return ResultFormat.parse(requested_format, default=configured_format)
+
+def sanitize_error_message(error: Exception) -> str:
+    """Remove credentials from database errors before returning them to clients."""
+    message = str(error)
+    password = os.getenv("MSSQL_PASSWORD")
+    if password:
+        message = message.replace(password, "<redacted>")
+    return re.sub(
+        r"(?i)(password\s*(?:=|:)?\s*)(?:'[^']*'|\"[^\"]*\"|[^\s,;]+)",
+        r"\1<redacted>",
+        message,
+    )
+
+def get_result_store() -> ResultStore:
+    """Create a result store from the current environment configuration."""
+    return ResultStore.from_env()
+
+def format_tabular_result(
+    columns,
+    rows,
+    result_format: ResultFormat,
+    *,
+    store: ResultStore,
+    force_store: bool = False,
+    truncated: bool = False,
+) -> str:
+    """Return an inline result or a summary for a persisted oversized result."""
+    materialized_rows = list(rows)
+
+    # Without file-backed storage there is no threshold to evaluate. Preserve
+    # the requested wire format directly and avoid building an unused canonical
+    # JSON copy for legacy and CSV callers.
+    if not store.enabled and not force_store:
+        if result_format is ResultFormat.LEGACY:
+            return serialize_legacy(columns, materialized_rows)
+        if result_format is ResultFormat.CSV:
+            return serialize_csv(columns, materialized_rows)
+        envelope = build_result(columns, materialized_rows, truncated=truncated)
+        return serialize_json(envelope)
+
+    envelope = build_result(columns, materialized_rows, truncated=truncated)
+    payload_bytes = serialize_json(envelope).encode("utf-8")
+    if store.should_store(payload_bytes, envelope["row_count"], force=force_store):
+        return serialize_json(store.store(envelope, payload_bytes))
+    if result_format is ResultFormat.LEGACY:
+        return serialize_legacy(columns, materialized_rows)
+    return serialize_envelope(envelope, result_format)
+
+def _validate_tool_names(command: str) -> None:
+    if command in {GET_RESULT_TOOL, READ_RESULT_CHUNK_TOOL}:
+        raise ValueError(f"MSSQL_COMMAND conflicts with reserved tool name '{command}'")
+
 def is_select_query(query: str) -> bool:
     """
     Check if a query is a SELECT statement, accounting for comments.
@@ -125,6 +196,7 @@ def is_select_query(query: str) -> bool:
     first_word = query_cleaned.strip().split()[0] if query_cleaned.strip() else ""
     return first_word.upper() == "SELECT"
 
+
 # Initialize server
 app = Server("mssql_mcp_server")
 
@@ -132,6 +204,8 @@ app = Server("mssql_mcp_server")
 async def list_resources() -> list[Resource]:
     """List SQL Server tables as resources."""
     config = get_db_config()
+    conn = None
+    cursor = None
     try:
         conn = pymssql.connect(**config)
         cursor = conn.cursor()
@@ -148,18 +222,23 @@ async def list_resources() -> list[Resource]:
         for table in tables:
             resources.append(
                 Resource(
-                    uri=f"mssql://{table[0]}/data",
+                    uri=AnyUrl(f"mssql://{table[0]}/data"),
                     name=f"Table: {table[0]}",
+                    # MCP SDK 1.2 wraps string resources as text/plain. Keep the
+                    # catalog consistent until the SDK can carry a dynamic MIME.
                     mimeType="text/plain",
-                    description=f"Data in table: {table[0]}"
+                    description=f"Data in table: {table[0]}",
                 )
             )
-        cursor.close()
-        conn.close()
         return resources
-    except Exception as e:
-        logger.error(f"Failed to list resources: {str(e)}")
+    except Exception as e:  # noqa: BLE001 - MCP resource-list boundary
+        logger.error(f"Failed to list resources: {e!s}")
         return []
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if conn is not None:
+            conn.close()
 
 @app.read_resource()
 async def read_resource(uri: AnyUrl) -> str:
@@ -173,32 +252,47 @@ async def read_resource(uri: AnyUrl) -> str:
         
     parts = uri_str[8:].split('/')
     table = parts[0]
+    result_format = get_result_format()
+    store = get_result_store()
+    use_sentinel_row = result_format is ResultFormat.JSON or store.enabled
+    row_limit = 101 if use_sentinel_row else 100
     
+    conn = None
+    cursor = None
     try:
         # Validate table name to prevent SQL injection
         safe_table = validate_table_name(table)
         
         conn = pymssql.connect(**config)
         cursor = conn.cursor()
-        # Use TOP 100 for MSSQL (equivalent to LIMIT in MySQL)
-        cursor.execute(f"SELECT TOP 100 * FROM {safe_table}")
+        cursor.execute(f"SELECT TOP {row_limit} * FROM {safe_table}")
         columns = [desc[0] for desc in cursor.description]
         rows = cursor.fetchall()
-        result = [",".join(map(str, row)) for row in rows]
-        cursor.close()
-        conn.close()
-        return "\n".join([",".join(columns)] + result)
+        truncated = use_sentinel_row and len(rows) > 100
+        return format_tabular_result(
+            columns,
+            rows[:100],
+            result_format,
+            store=store,
+            truncated=truncated,
+        )
                 
-    except Exception as e:
-        logger.error(f"Database error reading resource {uri}: {str(e)}")
-        raise RuntimeError(f"Database error: {str(e)}")
+    except Exception as e:  # noqa: BLE001 - MCP resource boundary
+        logger.error(f"Database error reading resource {uri}: {e!s}")
+        raise RuntimeError(f"Database error: {e!s}")
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if conn is not None:
+            conn.close()
 
 @app.list_tools()
 async def list_tools() -> list[Tool]:
     """List available SQL Server tools."""
     command = get_command()
+    _validate_tool_names(command)
     logger.info("Listing tools...")
-    return [
+    tools = [
         Tool(
             name=command,
             description="Execute an SQL query on the SQL Server",
@@ -207,62 +301,184 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "The SQL query to execute"
-                    }
+                        "description": "The SQL query to execute",
+                    },
+                    "result_format": {
+                        "type": "string",
+                        "enum": [item.value for item in ResultFormat],
+                        "description": (
+                            "Optional query result format. Defaults to "
+                            "MSSQL_RESULT_FORMAT or legacy."
+                        ),
+                    },
+                    "store_result": {
+                        "type": "boolean",
+                        "description": (
+                            "Persist the full JSON result even when it is below "
+                            "the configured thresholds. Requires "
+                            "MSSQL_RESULT_OUTPUT_DIR."
+                        ),
+                    },
                 },
-                "required": ["query"]
-            }
+                "required": ["query"],
+            },
         )
     ]
+    store = get_result_store()
+    if store.enabled:
+        tools.extend(
+            [
+                Tool(
+                    name=GET_RESULT_TOOL,
+                    description="Read a stored SQL result using row pagination",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "result_id": {
+                                "type": "string",
+                                "pattern": "^[0-9a-f]{32}$",
+                            },
+                            "offset": {"type": "integer", "minimum": 0},
+                            "limit": {"type": "integer", "minimum": 1},
+                        },
+                        "required": ["result_id"],
+                    },
+                ),
+                Tool(
+                    name=READ_RESULT_CHUNK_TOOL,
+                    description=("Read bounded base64 chunks of a stored JSON result"),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "result_id": {
+                                "type": "string",
+                                "pattern": "^[0-9a-f]{32}$",
+                            },
+                            "offset_bytes": {
+                                "type": "integer",
+                                "minimum": 0,
+                            },
+                            "max_bytes": {"type": "integer", "minimum": 1},
+                        },
+                        "required": ["result_id"],
+                    },
+                ),
+            ]
+        )
+    return tools
 
 @app.call_tool()
 async def call_tool(name: str, arguments: dict) -> list[TextContent]:
     """Execute SQL commands."""
-    config = get_db_config()
     command = get_command()
+    _validate_tool_names(command)
     logger.info(f"Calling tool: {name} with arguments: {arguments}")
+
+    if not isinstance(arguments, dict):
+        raise ValueError("Tool arguments must be an object")  # noqa: TRY004
+
+    if name == GET_RESULT_TOOL:
+        result_id = arguments.get("result_id")
+        if not isinstance(result_id, str):
+            raise ValueError("result_id is required")
+        store = get_result_store()
+        page = store.read_page(
+            result_id,
+            offset=arguments.get("offset", 0),
+            limit=arguments.get("limit"),
+        )
+        return [TextContent(type="text", text=serialize_json(page))]
+
+    if name == READ_RESULT_CHUNK_TOOL:
+        result_id = arguments.get("result_id")
+        if not isinstance(result_id, str):
+            raise ValueError("result_id is required")
+        store = get_result_store()
+        chunk = store.read_chunk(
+            result_id,
+            offset_bytes=arguments.get("offset_bytes", 0),
+            max_bytes=arguments.get("max_bytes"),
+        )
+        return [TextContent(type="text", text=serialize_json(chunk))]
     
     if name != command:
         raise ValueError(f"Unknown tool: {name}")
     
     query = arguments.get("query")
-    if not query:
+    if not isinstance(query, str) or not query.strip():
         raise ValueError("Query is required")
     
+    result_format = get_result_format(arguments.get("result_format"))
+    force_store = arguments.get("store_result", False)
+    if not isinstance(force_store, bool):
+        raise ValueError("store_result must be a boolean")  # noqa: TRY004
+    store = get_result_store()
+    if force_store and not store.enabled:
+        raise ValueError(
+            "store_result requires MSSQL_RESULT_OUTPUT_DIR to be configured"
+        )
+    config = get_db_config()
+
+    conn = None
+    cursor = None
+    columns = None
+    rows = None
+    affected_rows = None
     try:
         conn = pymssql.connect(**config)
         cursor = conn.cursor()
         cursor.execute(query)
         
-        # Special handling for table listing
-        if is_select_query(query) and "INFORMATION_SCHEMA.TABLES" in query.upper():
-            tables = cursor.fetchall()
-            result = ["Tables_in_" + config["database"]]  # Header
-            result.extend([table[0] for table in tables])
-            cursor.close()
-            conn.close()
-            return [TextContent(type="text", text="\n".join(result))]
-        
-        # Regular SELECT queries
-        elif is_select_query(query):
+        # A cursor description is the driver-level signal that the statement
+        # returned rows. This also covers CTEs and stored procedures.
+        if cursor.description is not None:
             columns = [desc[0] for desc in cursor.description]
             rows = cursor.fetchall()
-            result = [",".join(map(str, row)) for row in rows]
-            cursor.close()
-            conn.close()
-            return [TextContent(type="text", text="\n".join([",".join(columns)] + result))]
-        
-        # Non-SELECT queries
         else:
-            conn.commit()
             affected_rows = cursor.rowcount
-            cursor.close()
-            conn.close()
-            return [TextContent(type="text", text=f"Query executed successfully. Rows affected: {affected_rows}")]
+        
+        # Commit every successfully executed statement, including statements
+        # that return rows (for example UPDATE ... OUTPUT and stored procedures).
+        # Result rows must be fetched before commit because some drivers discard
+        # an active result set when the transaction is completed.
+        conn.commit()
                 
     except Exception as e:
-        logger.error(f"Error executing SQL '{query}': {e}")
-        return [TextContent(type="text", text=f"Error executing query: {str(e)}")]
+        safe_message = sanitize_error_message(e)
+        logger.error(f"Error executing SQL query: {safe_message}")
+        raise RuntimeError(f"Error executing query: {safe_message}") from e
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if conn is not None:
+            conn.close()
+
+    # Keep result serialization and persistence outside the database exception
+    # boundary so post-processing failures are not mislabeled as SQL errors.
+    if columns is not None and rows is not None:
+        if (
+            result_format is ResultFormat.LEGACY
+            and is_select_query(query)
+            and "INFORMATION_SCHEMA.TABLES" in query.upper()
+        ):
+            columns = ["Tables_in_" + config["database"]]
+            rows = [[row[0]] for row in rows]
+        text = format_tabular_result(
+            columns,
+            rows,
+            result_format,
+            store=store,
+            force_store=force_store,
+        )
+        return [TextContent(type="text", text=text)]
+
+    return [
+        TextContent(
+            type="text",
+            text=f"Query executed successfully. Rows affected: {affected_rows}",
+        )
+    ]
+
 
 async def main():
     """Main entry point to run the MCP server."""
@@ -284,8 +500,8 @@ async def main():
                 write_stream,
                 app.create_initialization_options()
             )
-        except Exception as e:
-            logger.error(f"Server error: {str(e)}", exc_info=True)
+        except Exception:
+            logger.exception("Server error")
             raise
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 # tests/conftest.py
-import pytest
 import os
+
 import pymssql
+import pytest
+
 
 @pytest.fixture(scope="session")
 def mssql_connection():

--- a/tests/handler_adapter.py
+++ b/tests/handler_adapter.py
@@ -1,0 +1,26 @@
+"""Expose registered MCP handlers directly to unit-style tests."""
+
+from mssql_mcp_server.server import (
+    app as server_app,
+)
+from mssql_mcp_server.server import (
+    call_tool,
+    list_resources,
+    list_tools,
+    read_resource,
+)
+
+
+class DirectHandlerAdapter:
+    """Keep Server metadata while calling decorated handlers directly."""
+
+    call_tool = staticmethod(call_tool)
+    list_resources = staticmethod(list_resources)
+    list_tools = staticmethod(list_tools)
+    read_resource = staticmethod(read_resource)
+
+    def __getattr__(self, name):
+        return getattr(server_app, name)
+
+
+app = DirectHandlerAdapter()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,9 @@
 """Test database configuration and environment variable handling."""
-import pytest
 import os
 from unittest.mock import patch
+
+import pytest
+
 from mssql_mcp_server.server import get_db_config, validate_table_name
 
 
@@ -20,8 +22,8 @@ class TestDatabaseConfiguration:
             assert config['user'] == 'testuser'
             assert config['password'] == 'testpass'
             assert config['database'] == 'testdb'
-            assert 'port' not in config
-    
+            assert config['port'] == '1433'
+
     def test_custom_server_and_port(self):
         """Test custom server and port configuration."""
         with patch.dict(os.environ, {
@@ -44,7 +46,7 @@ class TestDatabaseConfiguration:
             'MSSQL_DATABASE': 'testdb'
         }):
             config = get_db_config()
-            assert 'port' not in config  # Invalid port should be ignored
+            assert config['port'] == '1433'  # Invalid value falls back to default
     
     def test_azure_sql_configuration(self):
         """Test Azure SQL automatic encryption configuration."""
@@ -55,7 +57,7 @@ class TestDatabaseConfiguration:
             'MSSQL_DATABASE': 'testdb'
         }):
             config = get_db_config()
-            assert config['encrypt'] == True
+            assert config['server'].endswith(';Encrypt=yes;TrustServerCertificate=no')
             assert config['tds_version'] == '7.4'
     
     def test_localdb_configuration(self):
@@ -108,8 +110,9 @@ class TestDatabaseConfiguration:
             'MSSQL_DATABASE': 'testdb'
         }):
             config = get_db_config()
-            assert config['encrypt'] == True
-        
+            assert config['server'].endswith(';Encrypt=yes;TrustServerCertificate=yes')
+            assert config['tds_version'] == '7.4'
+
         # Non-Azure without encryption (default)
         with patch.dict(os.environ, {
             'MSSQL_SERVER': 'localhost',
@@ -118,7 +121,8 @@ class TestDatabaseConfiguration:
             'MSSQL_DATABASE': 'testdb'
         }):
             config = get_db_config()
-            assert config['encrypt'] == False
+            assert config['server'] == 'localhost'
+            assert 'tds_version' not in config
 
 
 class TestTableNameValidation:

--- a/tests/test_context_benchmark.py
+++ b/tests/test_context_benchmark.py
@@ -18,7 +18,6 @@ def test_measure_context_reports_before_and_after_for_240_rows():
         "row_count": 240,
         "stored": True,
         "result_id": "0" * 32,
-        "result_path": "/var/lib/mssql-results/0.json",
         "preview_rows": [],
         "truncated": False,
     }
@@ -38,7 +37,6 @@ def test_measure_context_reports_large_definition_savings():
         "row_count": 1,
         "stored": True,
         "result_id": "1" * 32,
-        "result_path": "/var/lib/mssql-results/1.json",
         "preview_rows": [],
         "truncated": False,
     }

--- a/tests/test_context_benchmark.py
+++ b/tests/test_context_benchmark.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+from runpy import run_path
+
+from mssql_mcp_server.serialization import build_result
+
+measure_context = run_path(
+    str(Path(__file__).parents[1] / "benchmarks" / "measure_result_context.py")
+)["measure_context"]
+
+
+def test_measure_context_reports_before_and_after_for_240_rows():
+    envelope = build_result(
+        ["id", "key_columns"],
+        [[index, f"Region, Segment,{index}"] for index in range(240)],
+    )
+    summary = {
+        "columns": envelope["columns"],
+        "row_count": 240,
+        "stored": True,
+        "result_id": "0" * 32,
+        "result_path": "/var/lib/mssql-results/0.json",
+        "preview_rows": [],
+        "truncated": False,
+    }
+
+    metrics = measure_context(envelope, summary=summary)
+
+    assert metrics["legacy_inline"]["utf8_bytes"] > 5_000
+    assert metrics["stored_summary"]["utf8_bytes"] < 300
+    assert metrics["savings_vs_legacy_inline"]["percent"] > 90
+    assert metrics["savings_vs_json_inline"]["estimated_tokens"] > 1_000
+
+
+def test_measure_context_reports_large_definition_savings():
+    envelope = build_result(["definition"], [["x," * 31_000]])
+    summary = {
+        "columns": ["definition"],
+        "row_count": 1,
+        "stored": True,
+        "result_id": "1" * 32,
+        "result_path": "/var/lib/mssql-results/1.json",
+        "preview_rows": [],
+        "truncated": False,
+    }
+
+    metrics = measure_context(envelope, summary=summary)
+
+    assert metrics["json_inline"]["utf8_bytes"] > 62_000
+    assert metrics["stored_summary"]["utf8_bytes"] < 300
+    assert metrics["savings_vs_json_inline"]["percent"] > 99
+
+
+def test_measure_context_rejects_invalid_token_ratio():
+    envelope = build_result(["id"], [[1]])
+
+    try:
+        measure_context(envelope, bytes_per_token=0)
+    except ValueError as exc:
+        assert "greater than zero" in str(exc)
+    else:
+        raise AssertionError("Expected invalid token ratio to fail")

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,9 +1,10 @@
 """Test error handling, resilience, and recovery scenarios."""
-import pytest
 import asyncio
-from unittest.mock import Mock, patch, PropertyMock
-from mssql_mcp_server.server import app, get_db_config
+from unittest.mock import Mock, patch
+
 import pymssql
+import pytest
+from handler_adapter import app
 
 
 class TestConnectionErrors:
@@ -67,9 +68,9 @@ class TestConnectionErrors:
                 'MSSQL_PASSWORD': 'test',
                 'MSSQL_DATABASE': 'testdb'
             }):
-                result = await app.call_tool("execute_sql", {"query": "SELECT * FROM users"})
-                assert "Error executing query" in result[0].text
-                
+                with pytest.raises(RuntimeError, match="Network error"):
+                    await app.call_tool("execute_sql", {"query": "SELECT * FROM users"})
+
                 # Ensure cleanup attempted
                 mock_cursor.close.assert_called()
                 mock_conn.close.assert_called()
@@ -93,9 +94,8 @@ class TestQueryErrors:
                 'MSSQL_PASSWORD': 'test',
                 'MSSQL_DATABASE': 'testdb'
             }):
-                result = await app.call_tool("execute_sql", {"query": "SELCT * FROM users"})
-                assert "Error executing query" in result[0].text
-                assert len(result) == 1
+                with pytest.raises(RuntimeError, match="Incorrect syntax"):
+                    await app.call_tool("execute_sql", {"query": "SELCT * FROM users"})
     
     @pytest.mark.asyncio
     async def test_permission_denied(self):
@@ -112,8 +112,10 @@ class TestQueryErrors:
                 'MSSQL_PASSWORD': 'test',
                 'MSSQL_DATABASE': 'testdb'
             }):
-                result = await app.call_tool("execute_sql", {"query": "SELECT * FROM sensitive_table"})
-                assert "Error executing query" in result[0].text
+                with pytest.raises(RuntimeError, match="permission was denied"):
+                    await app.call_tool(
+                        "execute_sql", {"query": "SELECT * FROM sensitive_table"}
+                    )
     
     @pytest.mark.asyncio
     async def test_deadlock_handling(self):
@@ -130,10 +132,10 @@ class TestQueryErrors:
                 'MSSQL_PASSWORD': 'test',
                 'MSSQL_DATABASE': 'testdb'
             }):
-                result = await app.call_tool("execute_sql", {
-                    "query": "UPDATE users SET status = 'active'"
-                })
-                assert "Error executing query" in result[0].text
+                with pytest.raises(RuntimeError, match="deadlocked"):
+                    await app.call_tool("execute_sql", {
+                        "query": "UPDATE users SET status = 'active'"
+                    })
 
 
 class TestResourceErrors:
@@ -245,7 +247,6 @@ class TestRecoveryScenarios:
         
         async def slow_execute(query):
             await asyncio.sleep(0.1)  # Simulate slow query
-            return None
         
         mock_cursor.execute = Mock(side_effect=lambda q: None)
         mock_cursor.fetchall.return_value = [(1,)]
@@ -282,8 +283,9 @@ class TestMemoryAndResourceManagement:
                 'MSSQL_PASSWORD': 'test',
                 'MSSQL_DATABASE': 'testdb'
             }):
-                result = await app.call_tool("execute_sql", {"query": "SELECT * FROM users"})
-                
+                with pytest.raises(RuntimeError, match="Unexpected error"):
+                    await app.call_tool("execute_sql", {"query": "SELECT * FROM users"})
+
                 # Cursor should be closed despite error
                 mock_cursor.close.assert_called()
                 mock_conn.close.assert_called()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,10 @@
 """Integration tests for MCP protocol communication and end-to-end functionality."""
-import pytest
 import asyncio
-import json
-from unittest.mock import Mock, patch, AsyncMock
-from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Resource, Tool
-from mssql_mcp_server.server import app
+from unittest.mock import Mock, patch
+
+import pytest
+from handler_adapter import app
+from mcp.types import Resource, TextContent
 
 
 class TestMCPProtocolIntegration:
@@ -23,10 +22,6 @@ class TestMCPProtocolIntegration:
     @pytest.mark.asyncio
     async def test_full_mcp_lifecycle(self):
         """Test complete MCP server lifecycle from init to shutdown."""
-        # Mock the stdio streams
-        mock_read_stream = AsyncMock()
-        mock_write_stream = AsyncMock()
-        
         # Mock database connection
         mock_conn = Mock()
         mock_cursor = Mock()
@@ -132,7 +127,8 @@ class TestDatabaseIntegration:
         mock_cursor = Mock()
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.rowcount = 1
-        
+        mock_cursor.description = None  # INSERT returns no rowset
+
         with patch('pymssql.connect', return_value=mock_conn):
             with patch.dict('os.environ', {
                 'MSSQL_USER': 'test',

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,13 +1,13 @@
 """Performance and load tests for production readiness."""
-import pytest
 import asyncio
+import gc
+import os
 import time
 from unittest.mock import Mock, patch
-from concurrent.futures import ThreadPoolExecutor
-import gc
+
 import psutil
-import os
-from mssql_mcp_server.server import app
+import pytest
+from handler_adapter import app
 
 
 class TestPerformance:

--- a/tests/test_query_results.py
+++ b/tests/test_query_results.py
@@ -1,0 +1,760 @@
+import base64
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from mcp.types import (
+    CallToolRequest,
+    CallToolRequestParams,
+    ListResourcesRequest,
+    ListToolsRequest,
+    ReadResourceRequest,
+    ReadResourceRequestParams,
+)
+from pydantic import AnyUrl
+
+from mssql_mcp_server.serialization import build_result
+from mssql_mcp_server.server import (
+    GET_RESULT_TOOL,
+    READ_RESULT_CHUNK_TOOL,
+    app,
+    call_tool,
+    list_resources,
+    list_tools,
+    read_resource,
+)
+
+DB_ENV = {
+    "MSSQL_USER": "test",
+    "MSSQL_PASSWORD": "test-password",
+    "MSSQL_DATABASE": "testdb",
+    "MSSQL_RESULT_FORMAT": "json",
+}
+
+
+def make_connection(columns, rows):
+    cursor = Mock()
+    cursor.description = [(column,) for column in columns]
+    cursor.fetchall.return_value = rows
+    connection = Mock()
+    connection.cursor.return_value = cursor
+    return connection, cursor
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_json_when_configured():
+    connection, cursor = make_connection(
+        ["key_columns", "definition"],
+        [["Region, Segment", "SELECT a, b\r\nFROM 表格"]],
+    )
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        content = await call_tool("execute_sql", {"query": "SELECT 1"})
+
+    assert json.loads(content[0].text) == {
+        "columns": ["key_columns", "definition"],
+        "rows": [["Region, Segment", "SELECT a, b\r\nFROM 表格"]],
+        "row_count": 1,
+        "truncated": False,
+    }
+    cursor.close.assert_called_once_with()
+    connection.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_csv_override_is_legal_csv():
+    connection, _ = make_connection(["value"], [["one,two"]])
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        content = await call_tool(
+            "execute_sql", {"query": "SELECT 1", "result_format": "csv"}
+        )
+
+    assert content[0].text == 'value\n"one,two"'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("result_format", "expected"),
+    [
+        ("legacy", "value\none,two"),
+        ("csv", 'value\n"one,two"'),
+    ],
+)
+async def test_storage_disabled_legacy_and_csv_skip_canonical_json(
+    result_format, expected
+):
+    connection, _ = make_connection(["value"], [["one,two"]])
+    store = Mock(enabled=False)
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+        patch(
+            "mssql_mcp_server.server.get_result_store", return_value=store
+        ) as get_store,
+        patch(
+            "mssql_mcp_server.server.build_result",
+            side_effect=AssertionError("canonical JSON should not be built"),
+        ),
+    ):
+        content = await call_tool(
+            "execute_sql",
+            {"query": "SELECT value", "result_format": result_format},
+        )
+
+    assert content[0].text == expected
+    get_store.assert_called_once_with()
+    store.should_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_storage_disabled_json_builds_canonical_without_checking_thresholds():
+    connection, _ = make_connection(["id"], [[1]])
+    store = Mock(enabled=False)
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+        patch("mssql_mcp_server.server.get_result_store", return_value=store),
+        patch(
+            "mssql_mcp_server.server.build_result", wraps=build_result
+        ) as build_canonical,
+    ):
+        content = await call_tool("execute_sql", {"query": "SELECT id"})
+
+    assert json.loads(content[0].text)["rows"] == [[1]]
+    build_canonical.assert_called_once_with(["id"], [[1]], truncated=False)
+    store.should_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_defaults_to_legacy_output_for_compatibility():
+    connection, _ = make_connection(
+        ["key_columns", "nullable"], [["Region, Segment", None]]
+    )
+    legacy_env = {
+        key: value for key, value in DB_ENV.items() if key != "MSSQL_RESULT_FORMAT"
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", legacy_env, clear=True),
+    ):
+        content = await call_tool("execute_sql", {"query": "SELECT 1"})
+
+    assert content[0].text == "key_columns,nullable\nRegion, Segment,None"
+
+
+@pytest.mark.asyncio
+async def test_legacy_table_listing_preserves_original_header():
+    connection, _ = make_connection(["TABLE_NAME"], [["users"], ["products"]])
+    legacy_env = {
+        key: value for key, value in DB_ENV.items() if key != "MSSQL_RESULT_FORMAT"
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", legacy_env, clear=True),
+    ):
+        content = await call_tool(
+            "execute_sql",
+            {"query": "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"},
+        )
+
+    assert content[0].text == "Tables_in_testdb\nusers\nproducts"
+
+
+@pytest.mark.asyncio
+async def test_resource_and_tool_share_the_same_json_shape():
+    tool_connection, _ = make_connection(["id", "value"], [[1, None]])
+    resource_connection, _ = make_connection(["id", "value"], [[1, None]])
+
+    with (
+        patch("pymssql.connect", side_effect=[tool_connection, resource_connection]),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        tool_content = await call_tool("execute_sql", {"query": "SELECT 1"})
+        resource_content = await read_resource(AnyUrl("mssql://users/data"))
+
+    assert json.loads(tool_content[0].text) == json.loads(resource_content)
+
+
+@pytest.mark.asyncio
+async def test_resource_reports_when_top_100_view_is_truncated():
+    connection, cursor = make_connection(["id"], [[index] for index in range(101)])
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        resource_content = await read_resource(AnyUrl("mssql://users/data"))
+
+    result = json.loads(resource_content)
+    assert result["row_count"] == 100
+    assert result["truncated"] is True
+    assert result["rows"][-1] == [99]
+    cursor.execute.assert_called_once_with("SELECT TOP 101 * FROM [users]")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_format", ["legacy", "csv"])
+async def test_resource_preserves_top_100_without_json_or_storage(result_format):
+    connection, cursor = make_connection(["id"], [[1]])
+    env = {**DB_ENV, "MSSQL_RESULT_FORMAT": result_format}
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        await read_resource(AnyUrl("mssql://users/data"))
+
+    cursor.execute.assert_called_once_with("SELECT TOP 100 * FROM [users]")
+
+
+@pytest.mark.asyncio
+async def test_resource_uses_sentinel_row_when_storage_is_enabled(tmp_path):
+    connection, cursor = make_connection(["id"], [[1]])
+    env = {
+        **DB_ENV,
+        "MSSQL_RESULT_FORMAT": "legacy",
+        "MSSQL_RESULT_OUTPUT_DIR": str(tmp_path),
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        await read_resource(AnyUrl("mssql://users/data"))
+
+    cursor.execute.assert_called_once_with("SELECT TOP 101 * FROM [users]")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_format", ["legacy", "json", "csv", "invalid"])
+async def test_resource_catalog_always_advertises_text_plain(result_format):
+    connection, _ = make_connection(["TABLE_NAME"], [["users"]])
+    env = {**DB_ENV, "MSSQL_RESULT_FORMAT": result_format}
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+        patch("mssql_mcp_server.server.get_result_store") as get_store,
+    ):
+        resources = await list_resources()
+
+    assert len(resources) == 1
+    assert resources[0].mimeType == "text/plain"
+    get_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT id FROM records",
+        "WITH data AS (SELECT 1 AS id) SELECT id FROM data",
+        "UPDATE records SET active = 1 OUTPUT inserted.id",
+        "DELETE FROM records OUTPUT deleted.id",
+        "UPDATE records SET active = 1; SELECT id FROM records",
+        "EXEC dbo.update_and_get_data",
+    ],
+    ids=[
+        "select",
+        "cte",
+        "update-output",
+        "delete-output",
+        "write-select",
+        "write-procedure",
+    ],
+)
+async def test_row_returning_statements_fetch_before_committing_once(query):
+    connection, cursor = make_connection(["id"], [[1]])
+    operations = []
+
+    def fetch_rows():
+        operations.append("fetch")
+        return [[1]]
+
+    def commit_transaction():
+        operations.append("commit")
+
+    cursor.fetchall.side_effect = fetch_rows
+    connection.commit.side_effect = commit_transaction
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        content = await call_tool("execute_sql", {"query": query})
+
+    assert json.loads(content[0].text)["rows"] == [[1]]
+    assert operations == ["fetch", "commit"]
+    cursor.fetchall.assert_called_once_with()
+    connection.commit.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_non_query_success_semantics_are_unchanged():
+    connection, cursor = make_connection([], [])
+    cursor.description = None
+    cursor.rowcount = 3
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        content = await call_tool("execute_sql", {"query": "UPDATE t SET value = 1"})
+
+    assert content[0].text == "Query executed successfully. Rows affected: 3"
+    connection.commit.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_operation", ["execute", "fetch", "commit"])
+async def test_database_operation_errors_raise_as_sql_errors(failing_operation):
+    connection, cursor = make_connection([], [])
+    cursor.description = [("id",)]
+    error = RuntimeError(f"{failing_operation} failed")
+    if failing_operation == "execute":
+        cursor.execute.side_effect = error
+    elif failing_operation == "fetch":
+        cursor.fetchall.side_effect = error
+    else:
+        cursor.fetchall.return_value = [[1]]
+        connection.commit.side_effect = error
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+        pytest.raises(
+            RuntimeError,
+            match=rf"Error executing query: {failing_operation} failed",
+        ),
+    ):
+        await call_tool("execute_sql", {"query": "SELECT nope"})
+
+    if failing_operation in {"execute", "fetch"}:
+        connection.commit.assert_not_called()
+    else:
+        connection.commit.assert_called_once_with()
+    cursor.close.assert_called_once_with()
+    connection.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_post_processing_errors_are_not_mislabeled_as_sql_errors():
+    connection, cursor = make_connection(["id"], [[1]])
+
+    def fail_after_cleanup(*_args, **_kwargs):
+        cursor.close.assert_called_once_with()
+        connection.close.assert_called_once_with()
+        raise RuntimeError("result post-processing failed")
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+        patch(
+            "mssql_mcp_server.server.format_tabular_result",
+            side_effect=fail_after_cleanup,
+        ),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        await call_tool("execute_sql", {"query": "SELECT id FROM records"})
+
+    assert str(exc_info.value) == "result post-processing failed"
+    assert "Error executing query" not in str(exc_info.value)
+    connection.commit.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_sql_errors_redact_configured_passwords():
+    connection, cursor = make_connection([], [])
+    cursor.execute.side_effect = RuntimeError(
+        "Login failed with password 'test-password'"
+    )
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        await call_tool("execute_sql", {"query": "SELECT nope"})
+
+    assert "test-password" not in str(exc_info.value)
+    assert "password <redacted>" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_protocol_marks_sql_exceptions_as_errors():
+    connection, cursor = make_connection([], [])
+    cursor.execute.side_effect = RuntimeError("invalid SQL")
+    request = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(
+            name="execute_sql", arguments={"query": "SELECT nope"}
+        ),
+    )
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        result = await app.request_handlers[CallToolRequest](request)
+
+    assert result.root.isError is True
+    assert "Error executing query" in result.root.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_protocol_dispatches_successful_tool_call():
+    connection, _ = make_connection(["id", "value"], [[1, "one,two"]])
+    request = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(
+            name="execute_sql", arguments={"query": "SELECT id, value"}
+        ),
+    )
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        result = await app.request_handlers[CallToolRequest](request)
+
+    assert result.root.isError is False
+    assert json.loads(result.root.content[0].text) == {
+        "columns": ["id", "value"],
+        "rows": [[1, "one,two"]],
+        "row_count": 1,
+        "truncated": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_protocol_dispatches_tool_catalog():
+    request = ListToolsRequest(method="tools/list")
+
+    with patch.dict("os.environ", {}, clear=True):
+        result = await app.request_handlers[ListToolsRequest](request)
+
+    assert [tool.name for tool in result.root.tools] == ["execute_sql"]
+
+
+@pytest.mark.asyncio
+async def test_protocol_dispatches_resource_catalog():
+    connection, _ = make_connection(["TABLE_NAME"], [["users"]])
+    request = ListResourcesRequest(method="resources/list")
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        result = await app.request_handlers[ListResourcesRequest](request)
+
+    assert len(result.root.resources) == 1
+    assert str(result.root.resources[0].uri) == "mssql://users/data"
+    assert result.root.resources[0].mimeType == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_protocol_dispatches_resource_read_as_text_plain():
+    connection, _ = make_connection(["id", "value"], [[1, "one,two"]])
+    request = ReadResourceRequest(
+        method="resources/read",
+        params=ReadResourceRequestParams(uri=AnyUrl("mssql://users/data")),
+    )
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+    ):
+        result = await app.request_handlers[ReadResourceRequest](request)
+
+    assert len(result.root.contents) == 1
+    assert result.root.contents[0].mimeType == "text/plain"
+    assert json.loads(result.root.contents[0].text) == {
+        "columns": ["id", "value"],
+        "rows": [[1, "one,two"]],
+        "row_count": 1,
+        "truncated": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_tool_schema_advertises_optional_result_format():
+    with patch.dict("os.environ", {}, clear=True):
+        tools = await list_tools()
+
+    schema = tools[0].inputSchema
+    assert schema["properties"]["result_format"]["enum"] == [
+        "legacy",
+        "json",
+        "csv",
+    ]
+    assert schema["properties"]["store_result"]["type"] == "boolean"
+    assert schema["required"] == ["query"]
+    assert len(tools) == 1
+
+
+@pytest.mark.asyncio
+async def test_store_using_handlers_resolve_one_store_per_invocation():
+    store = Mock(enabled=False)
+    store.read_page.return_value = {"rows": []}
+    store.read_chunk.return_value = {"data_base64": "", "eof": True}
+    resource_connection, _ = make_connection(["id"], [[1]])
+    legacy_env = {
+        key: value for key, value in DB_ENV.items() if key != "MSSQL_RESULT_FORMAT"
+    }
+
+    with (
+        patch("pymssql.connect", return_value=resource_connection),
+        patch.dict("os.environ", legacy_env, clear=True),
+        patch(
+            "mssql_mcp_server.server.get_result_store", return_value=store
+        ) as get_store,
+    ):
+        await list_tools()
+        get_store.assert_called_once_with()
+        get_store.reset_mock()
+
+        await read_resource(AnyUrl("mssql://users/data"))
+        get_store.assert_called_once_with()
+        get_store.reset_mock()
+
+        await call_tool(GET_RESULT_TOOL, {"result_id": "0" * 32})
+        get_store.assert_called_once_with()
+        get_store.reset_mock()
+
+        await call_tool(READ_RESULT_CHUNK_TOOL, {"result_id": "0" * 32})
+        get_store.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result_format", ["legacy", "csv"])
+async def test_storage_enabled_formats_use_canonical_json_threshold(
+    tmp_path, result_format
+):
+    rows = [[1], [2], [3]]
+    connection, _ = make_connection(["id"], rows)
+    env = {
+        **DB_ENV,
+        "MSSQL_RESULT_FORMAT": result_format,
+        "MSSQL_RESULT_OUTPUT_DIR": str(tmp_path),
+        "MSSQL_RESULT_MAX_INLINE_ROWS": "2",
+        "MSSQL_RESULT_MAX_INLINE_BYTES": "0",
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        content = await call_tool("execute_sql", {"query": "SELECT id"})
+
+    summary = json.loads(content[0].text)
+    assert summary["stored"] is True
+    stored = json.loads(Path(summary["result_path"]).read_text(encoding="utf-8"))
+    assert stored["rows"] == rows
+
+
+@pytest.mark.asyncio
+async def test_240_rows_are_stored_instead_of_returned_inline(tmp_path):
+    rows = [[index, f"key,{index}"] for index in range(240)]
+    connection, _ = make_connection(["id", "key_columns"], rows)
+    env = {
+        **DB_ENV,
+        "MSSQL_RESULT_OUTPUT_DIR": str(tmp_path),
+        "MSSQL_RESULT_MAX_INLINE_ROWS": "200",
+        "MSSQL_RESULT_MAX_INLINE_BYTES": "0",
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        content = await call_tool("execute_sql", {"query": "SELECT many rows"})
+
+    summary = json.loads(content[0].text)
+    assert summary["stored"] is True
+    assert summary["row_count"] == 240
+    assert "rows" not in summary
+    stored = json.loads(Path(summary["result_path"]).read_text(encoding="utf-8"))
+    assert stored["rows"] == rows
+    assert len(content[0].text.encode("utf-8")) < len(
+        json.dumps(stored, ensure_ascii=False).encode("utf-8")
+    )
+
+
+@pytest.mark.asyncio
+async def test_62kb_definition_is_stored_without_preview_leak(tmp_path):
+    definition = "SELECT x, y\r\n" + ("x," * 31_000)
+    connection, _ = make_connection(["definition"], [[definition]])
+    env = {
+        **DB_ENV,
+        "MSSQL_RESULT_OUTPUT_DIR": str(tmp_path),
+        "MSSQL_RESULT_MAX_INLINE_ROWS": "0",
+        "MSSQL_RESULT_MAX_INLINE_BYTES": "32768",
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        content = await call_tool("execute_sql", {"query": "SELECT definition"})
+
+    summary = json.loads(content[0].text)
+    assert summary["stored"] is True
+    assert summary["preview_rows"] == []
+    assert definition not in content[0].text
+    stored = json.loads(Path(summary["result_path"]).read_text(encoding="utf-8"))
+    assert stored["rows"] == [[definition]]
+
+
+@pytest.mark.asyncio
+async def test_storage_tools_are_advertised_only_when_enabled(tmp_path):
+    with patch.dict(
+        "os.environ", {"MSSQL_RESULT_OUTPUT_DIR": str(tmp_path)}, clear=True
+    ):
+        tools = await list_tools()
+
+    assert [tool.name for tool in tools] == [
+        "execute_sql",
+        GET_RESULT_TOOL,
+        READ_RESULT_CHUNK_TOOL,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stored_result_tools_page_and_reconstruct_payload(tmp_path):
+    rows = [[index, f"value-{index}"] for index in range(3)]
+    connection, _ = make_connection(["id", "value"], rows)
+    env = {
+        **DB_ENV,
+        "MSSQL_RESULT_OUTPUT_DIR": str(tmp_path),
+        "MSSQL_RESULT_MAX_INLINE_ROWS": "0",
+        "MSSQL_RESULT_MAX_INLINE_BYTES": "0",
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        stored_content = await call_tool(
+            "execute_sql", {"query": "SELECT rows", "store_result": True}
+        )
+        summary = json.loads(stored_content[0].text)
+        page_content = await call_tool(
+            GET_RESULT_TOOL,
+            {"result_id": summary["result_id"], "offset": 1, "limit": 2},
+        )
+        chunk_content = await call_tool(
+            READ_RESULT_CHUNK_TOOL,
+            {"result_id": summary["result_id"], "max_bytes": 16_384},
+        )
+
+    page = json.loads(page_content[0].text)
+    assert page["rows"] == rows[1:]
+    assert page["total_row_count"] == 3
+    assert page["returned_rows"] == 2
+    assert "row_count" not in page
+    assert page["has_more"] is False
+    chunk = json.loads(chunk_content[0].text)
+    assert json.loads(base64.b64decode(chunk["data_base64"]))["rows"] == rows
+
+
+@pytest.mark.asyncio
+async def test_protocol_dispatches_complete_stored_result_workflow(tmp_path):
+    rows = [[index, f"value-{index}"] for index in range(3)]
+    connection, _ = make_connection(["id", "value"], rows)
+    env = {
+        **DB_ENV,
+        "MSSQL_RESULT_OUTPUT_DIR": str(tmp_path),
+        "MSSQL_RESULT_TTL_SECONDS": "0",
+    }
+    execute_request = CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(
+            name="execute_sql",
+            arguments={"query": "SELECT rows", "store_result": True},
+        ),
+    )
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        execute_result = await app.request_handlers[CallToolRequest](execute_request)
+        summary = json.loads(execute_result.root.content[0].text)
+
+        tools_result = await app.request_handlers[ListToolsRequest](
+            ListToolsRequest(method="tools/list")
+        )
+
+        page_result = await app.request_handlers[CallToolRequest](
+            CallToolRequest(
+                method="tools/call",
+                params=CallToolRequestParams(
+                    name=GET_RESULT_TOOL,
+                    arguments={
+                        "result_id": summary["result_id"],
+                        "offset": 1,
+                        "limit": 2,
+                    },
+                ),
+            )
+        )
+        page = json.loads(page_result.root.content[0].text)
+
+        chunk_result = await app.request_handlers[CallToolRequest](
+            CallToolRequest(
+                method="tools/call",
+                params=CallToolRequestParams(
+                    name=READ_RESULT_CHUNK_TOOL,
+                    arguments={
+                        "result_id": summary["result_id"],
+                        "max_bytes": 16_384,
+                    },
+                ),
+            )
+        )
+        chunk = json.loads(chunk_result.root.content[0].text)
+
+    assert execute_result.root.isError is False
+    assert summary["stored"] is True
+    assert [tool.name for tool in tools_result.root.tools] == [
+        "execute_sql",
+        GET_RESULT_TOOL,
+        READ_RESULT_CHUNK_TOOL,
+    ]
+    assert page_result.root.isError is False
+    assert page["rows"] == rows[1:]
+    assert page["total_row_count"] == 3
+    assert "row_count" not in page
+    assert chunk_result.root.isError is False
+    assert chunk["eof"] is True
+    assert "sha256" not in chunk
+    assert json.loads(base64.b64decode(chunk["data_base64"])) == {
+        "columns": ["id", "value"],
+        "rows": rows,
+        "row_count": 3,
+        "truncated": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_force_storage_requires_configured_output_directory():
+    connection, _ = make_connection(["id"], [[1]])
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", DB_ENV, clear=True),
+        pytest.raises(ValueError, match="MSSQL_RESULT_OUTPUT_DIR"),
+    ):
+        await call_tool("execute_sql", {"query": "SELECT 1", "store_result": True})

--- a/tests/test_query_results.py
+++ b/tests/test_query_results.py
@@ -33,6 +33,10 @@ DB_ENV = {
 }
 
 
+def stored_path(result_dir: Path, summary: dict) -> Path:
+    return result_dir / f'{summary["result_id"]}.json'
+
+
 def make_connection(columns, rows):
     cursor = Mock()
     cursor.description = [(column,) for column in columns]
@@ -560,7 +564,8 @@ async def test_storage_enabled_formats_use_canonical_json_threshold(
 
     summary = json.loads(content[0].text)
     assert summary["stored"] is True
-    stored = json.loads(Path(summary["result_path"]).read_text(encoding="utf-8"))
+    assert "result_path" not in summary
+    stored = json.loads(stored_path(tmp_path, summary).read_text(encoding="utf-8"))
     assert stored["rows"] == rows
 
 
@@ -585,7 +590,8 @@ async def test_240_rows_are_stored_instead_of_returned_inline(tmp_path):
     assert summary["stored"] is True
     assert summary["row_count"] == 240
     assert "rows" not in summary
-    stored = json.loads(Path(summary["result_path"]).read_text(encoding="utf-8"))
+    assert "result_path" not in summary
+    stored = json.loads(stored_path(tmp_path, summary).read_text(encoding="utf-8"))
     assert stored["rows"] == rows
     assert len(content[0].text.encode("utf-8")) < len(
         json.dumps(stored, ensure_ascii=False).encode("utf-8")
@@ -613,8 +619,29 @@ async def test_62kb_definition_is_stored_without_preview_leak(tmp_path):
     assert summary["stored"] is True
     assert summary["preview_rows"] == []
     assert definition not in content[0].text
-    stored = json.loads(Path(summary["result_path"]).read_text(encoding="utf-8"))
+    stored = json.loads(stored_path(tmp_path, summary).read_text(encoding="utf-8"))
     assert stored["rows"] == [[definition]]
+
+
+@pytest.mark.asyncio
+async def test_stored_result_path_can_be_explicitly_enabled(tmp_path):
+    connection, _ = make_connection(["id"], [[1]])
+    env = {
+        **DB_ENV,
+        "MSSQL_RESULT_OUTPUT_DIR": str(tmp_path),
+        "MSSQL_RESULT_INCLUDE_PATH": "true",
+    }
+
+    with (
+        patch("pymssql.connect", return_value=connection),
+        patch.dict("os.environ", env, clear=True),
+    ):
+        content = await call_tool(
+            "execute_sql", {"query": "SELECT id", "store_result": True}
+        )
+
+    summary = json.loads(content[0].text)
+    assert summary["result_path"] == str(stored_path(tmp_path, summary))
 
 
 @pytest.mark.asyncio

--- a/tests/test_result_export.py
+++ b/tests/test_result_export.py
@@ -1,0 +1,202 @@
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from mssql_mcp_server.result_export import (
+    load_result_file,
+    load_stored_result,
+    main,
+)
+from mssql_mcp_server.result_store import ResultStore, ResultStoreConfig
+from mssql_mcp_server.serialization import build_result, serialize_json
+
+
+def store_result(result_dir: Path, envelope: dict) -> dict:
+    store = ResultStore(ResultStoreConfig(output_dir=result_dir, ttl_seconds=0))
+    payload = serialize_json(envelope).encode("utf-8")
+    return store.store(envelope, payload)
+
+
+def test_file_loader_preserves_unicode_commas_and_crlf(tmp_path):
+    envelope = build_result(
+        ["key_columns", "definition", "nullable"],
+        [["Region, Segment", "SELECT x, y\r\nFROM 表格", None]],
+    )
+    result_path = tmp_path / "result.json"
+    result_path.write_text(serialize_json(envelope), encoding="utf-8")
+
+    assert load_result_file(result_path) == envelope
+
+
+def test_cli_exports_file_as_compact_json_stdout(tmp_path, capsys):
+    envelope = build_result(["name"], [["中文\r\nvalue,with,commas"]])
+    result_path = tmp_path / "result.json"
+    result_path.write_text(serialize_json(envelope), encoding="utf-8")
+
+    assert main(["--results-json", str(result_path)]) == 0
+
+    assert capsys.readouterr().out == serialize_json(envelope) + "\n"
+
+
+def test_cli_exports_result_id_using_directory_override(tmp_path, capsys, monkeypatch):
+    result_dir = tmp_path / "results"
+    envelope = build_result(["id", "value"], [[1, "one,two"]])
+    summary = store_result(result_dir, envelope)
+    monkeypatch.delenv("MSSQL_RESULT_OUTPUT_DIR", raising=False)
+
+    assert (
+        main(
+            [
+                "--result-id",
+                summary["result_id"],
+                "--result-dir",
+                str(result_dir),
+            ]
+        )
+        == 0
+    )
+
+    assert json.loads(capsys.readouterr().out) == envelope
+
+
+def test_cli_exports_result_id_using_configured_directory(
+    tmp_path, capsys, monkeypatch
+):
+    result_dir = tmp_path / "results"
+    envelope = build_result(["id"], [[1]])
+    summary = store_result(result_dir, envelope)
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", str(result_dir))
+    monkeypatch.setenv("MSSQL_RESULT_TTL_SECONDS", "0")
+
+    assert main(["--result-id", summary["result_id"]]) == 0
+
+    assert json.loads(capsys.readouterr().out) == envelope
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "columns": ["id"],
+            "row_count": 1,
+            "stored": True,
+            "result_id": "0" * 32,
+            "preview_rows": [],
+            "truncated": False,
+        },
+        {
+            "columns": ["id"],
+            "rows": [[1]],
+            "total_row_count": 2,
+            "result_id": "0" * 32,
+            "offset": 0,
+            "returned_rows": 1,
+            "next_offset": 1,
+            "has_more": True,
+            "truncated": False,
+        },
+    ],
+)
+def test_file_loader_rejects_summary_and_page_payloads(tmp_path, payload):
+    result_path = tmp_path / "partial.json"
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="canonical result envelope"):
+        load_result_file(result_path)
+
+
+def test_file_loader_rejects_corrupt_json(tmp_path):
+    result_path = tmp_path / "corrupt.json"
+    result_path.write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unable to read result JSON"):
+        load_result_file(result_path)
+
+
+def test_file_loader_rejects_nonstandard_json_constants(tmp_path):
+    result_path = tmp_path / "nonstandard.json"
+    result_path.write_text(
+        '{"columns":["value"],"rows":[[NaN]],"row_count":1,' '"truncated":false}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Non-standard JSON constant"):
+        load_result_file(result_path)
+
+
+def test_stored_loader_rejects_corrupt_result(tmp_path, monkeypatch):
+    result_dir = tmp_path / "results"
+    envelope = build_result(["id"], [[1]])
+    summary = store_result(result_dir, envelope)
+    Path(summary["result_path"]).write_text("not-json", encoding="utf-8")
+    monkeypatch.setenv("MSSQL_RESULT_TTL_SECONDS", "0")
+
+    with pytest.raises(RuntimeError, match="corrupt"):
+        load_stored_result(summary["result_id"], result_dir)
+
+
+def test_directory_override_honors_configured_ttl(tmp_path, monkeypatch):
+    result_dir = tmp_path / "results"
+    envelope = build_result(["id"], [[1]])
+    summary = store_result(result_dir, envelope)
+    old_time = time.time() - 10
+    os.utime(summary["result_path"], (old_time, old_time))
+    monkeypatch.setenv("MSSQL_RESULT_TTL_SECONDS", "1")
+
+    with pytest.raises(FileNotFoundError, match="expired"):
+        load_stored_result(summary["result_id"], result_dir)
+
+
+def test_stored_loader_reuses_result_id_validation(tmp_path, monkeypatch):
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    monkeypatch.setenv("MSSQL_RESULT_TTL_SECONDS", "0")
+
+    with pytest.raises(ValueError, match="result_id"):
+        load_stored_result("../secret", result_dir)
+
+
+def test_stored_loader_does_not_create_a_missing_source_directory(
+    tmp_path, monkeypatch
+):
+    missing_dir = tmp_path / "missing-results"
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", str(missing_dir))
+
+    with pytest.raises(ValueError, match="Result directory does not exist"):
+        load_stored_result("0" * 32)
+
+    assert not missing_dir.exists()
+
+
+def test_directory_override_takes_precedence_over_configured_directory(
+    tmp_path, monkeypatch
+):
+    result_dir = tmp_path / "override-results"
+    envelope = build_result(["source"], [["override"]])
+    summary = store_result(result_dir, envelope)
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", "relative/invalid")
+    monkeypatch.setenv("MSSQL_RESULT_TTL_SECONDS", "0")
+
+    assert load_stored_result(summary["result_id"], result_dir) == envelope
+
+
+def test_result_directory_is_only_valid_with_result_id(tmp_path):
+    result_path = tmp_path / "result.json"
+    result_path.write_text(
+        serialize_json(build_result(["id"], [[1]])), encoding="utf-8"
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "--results-json",
+                str(result_path),
+                "--result-dir",
+                str(tmp_path),
+            ]
+        )
+
+    assert exc_info.value.code == 2

--- a/tests/test_result_export.py
+++ b/tests/test_result_export.py
@@ -20,6 +20,10 @@ def store_result(result_dir: Path, envelope: dict) -> dict:
     return store.store(envelope, payload)
 
 
+def stored_path(result_dir: Path, summary: dict) -> Path:
+    return result_dir / f'{summary["result_id"]}.json'
+
+
 def test_file_loader_preserves_unicode_commas_and_crlf(tmp_path):
     envelope = build_result(
         ["key_columns", "definition", "nullable"],
@@ -131,7 +135,7 @@ def test_stored_loader_rejects_corrupt_result(tmp_path, monkeypatch):
     result_dir = tmp_path / "results"
     envelope = build_result(["id"], [[1]])
     summary = store_result(result_dir, envelope)
-    Path(summary["result_path"]).write_text("not-json", encoding="utf-8")
+    stored_path(result_dir, summary).write_text("not-json", encoding="utf-8")
     monkeypatch.setenv("MSSQL_RESULT_TTL_SECONDS", "0")
 
     with pytest.raises(RuntimeError, match="corrupt"):
@@ -143,7 +147,7 @@ def test_directory_override_honors_configured_ttl(tmp_path, monkeypatch):
     envelope = build_result(["id"], [[1]])
     summary = store_result(result_dir, envelope)
     old_time = time.time() - 10
-    os.utime(summary["result_path"], (old_time, old_time))
+    os.utime(stored_path(result_dir, summary), (old_time, old_time))
     monkeypatch.setenv("MSSQL_RESULT_TTL_SECONDS", "1")
 
     with pytest.raises(FileNotFoundError, match="expired"):

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -1,0 +1,415 @@
+import base64
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mssql_mcp_server.result_store import ResultStore, ResultStoreConfig
+from mssql_mcp_server.serialization import build_result, serialize_json
+
+
+def make_store(tmp_path: Path, **overrides) -> ResultStore:
+    defaults = {
+        "output_dir": tmp_path,
+        "max_inline_rows": 2,
+        "max_inline_bytes": 1024,
+        "preview_rows": 2,
+        "preview_bytes": 256,
+        "default_page_rows": 2,
+        "max_page_rows": 10,
+        "max_page_bytes": 1024,
+        "max_page_source_bytes": 64 * 1024 * 1024,
+        "max_chunk_bytes": 16,
+        "ttl_seconds": 3600,
+        "max_store_bytes": 1024 * 1024,
+    }
+    defaults.update(overrides)
+    return ResultStore(ResultStoreConfig(**defaults))
+
+
+def persist(store: ResultStore, rows):
+    envelope = build_result(["id", "value"], rows)
+    payload = serialize_json(envelope).encode("utf-8")
+    return envelope, payload, store.store(envelope, payload)
+
+
+def test_storage_is_disabled_without_an_output_directory():
+    store = ResultStore(ResultStoreConfig())
+    payload = b"{}"
+
+    assert store.enabled is False
+    assert store.should_store(payload, 1000, force=False) is False
+    with pytest.raises(ValueError, match="MSSQL_RESULT_OUTPUT_DIR"):
+        store.should_store(payload, 1, force=True)
+
+
+def test_config_requires_an_absolute_output_directory(monkeypatch):
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", "relative/results")
+
+    with pytest.raises(ValueError, match="absolute path"):
+        ResultStoreConfig.from_env()
+
+
+@pytest.mark.parametrize("max_page_bytes", [-1, 1, 511, True])
+def test_config_rejects_invalid_positive_page_byte_caps(max_page_bytes):
+    with pytest.raises(ValueError, match="MSSQL_RESULT_MAX_PAGE_BYTES"):
+        ResultStoreConfig(max_page_bytes=max_page_bytes)
+
+
+def test_zero_disables_the_page_byte_cap():
+    assert ResultStoreConfig(max_page_bytes=0).max_page_bytes == 0
+
+
+def test_page_source_limit_defaults_to_64_mib():
+    assert ResultStoreConfig().max_page_source_bytes == 64 * 1024 * 1024
+
+
+@pytest.mark.parametrize("max_page_source_bytes", [-1, True])
+def test_config_rejects_invalid_page_source_limits(max_page_source_bytes):
+    with pytest.raises(ValueError, match="MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES"):
+        ResultStoreConfig(max_page_source_bytes=max_page_source_bytes)
+
+
+def test_config_rejects_negative_page_source_limit_from_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setenv("MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES", "-1")
+
+    with pytest.raises(ValueError, match="MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES"):
+        ResultStoreConfig.from_env()
+
+
+def test_zero_page_source_limit_is_preserved_from_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setenv("MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES", "0")
+
+    assert ResultStoreConfig.from_env().max_page_source_bytes == 0
+
+
+@pytest.mark.parametrize(
+    ("row_count", "payload_size", "expected"),
+    [
+        (2, 1024, False),
+        (3, 1024, True),
+        (2, 1025, True),
+    ],
+)
+def test_thresholds_trigger_only_when_exceeded(
+    tmp_path, row_count, payload_size, expected
+):
+    store = make_store(tmp_path)
+
+    assert store.should_store(b"x" * payload_size, row_count, force=False) is expected
+
+
+def test_stored_file_is_canonical_json_and_summary_is_bounded(tmp_path):
+    store = make_store(tmp_path)
+    rows = [[1, "Region, Segment"], [2, "中文\r\n多行"], [3, None]]
+    envelope, payload, summary = persist(store, rows)
+
+    result_path = Path(summary["result_path"])
+    assert result_path.parent == tmp_path.resolve()
+    assert result_path.read_bytes() == payload
+    assert json.loads(payload) == envelope
+    assert summary["columns"] == ["id", "value"]
+    assert summary["row_count"] == 3
+    assert summary["stored"] is True
+    assert summary["byte_count"] == len(payload)
+    assert summary["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert summary["preview_rows"] == rows[:2]
+    assert summary["truncated"] is False
+    assert summary["expires_at"] is not None
+    assert "rows" not in summary
+
+
+def test_large_single_cell_is_not_leaked_in_preview(tmp_path):
+    store = make_store(tmp_path, preview_bytes=128)
+    _, _, summary = persist(store, [[1, "x," * 31_000]])
+
+    assert summary["preview_rows"] == []
+    assert len(serialize_json(summary).encode("utf-8")) < 1024
+
+
+def test_row_pagination_preserves_order_without_overlap(tmp_path):
+    store = make_store(tmp_path)
+    rows = [[index, f"value-{index}"] for index in range(5)]
+    _, _, summary = persist(store, rows)
+
+    first = store.read_page(summary["result_id"], offset=0, limit=2)
+    second = store.read_page(summary["result_id"], offset=2, limit=2)
+    last = store.read_page(summary["result_id"], offset=4, limit=2)
+
+    assert first["rows"] + second["rows"] + last["rows"] == rows
+    assert first["next_offset"] == 2 and first["has_more"] is True
+    assert second["next_offset"] == 4 and second["has_more"] is True
+    assert last["next_offset"] == 5 and last["has_more"] is False
+    assert last["total_row_count"] == 5
+    assert last["returned_rows"] == 1
+    assert "row_count" not in last
+
+
+def test_row_page_stays_within_byte_cap(tmp_path):
+    store = make_store(tmp_path, max_page_bytes=512)
+    rows = [[index, "x" * 180] for index in range(5)]
+    _, _, summary = persist(store, rows)
+
+    page = store.read_page(summary["result_id"], offset=0, limit=5)
+
+    assert 0 < page["returned_rows"] < 5
+    assert len(serialize_json(page).encode("utf-8")) <= 512
+
+
+def test_oversized_row_requires_chunks_without_stalling_pagination(tmp_path):
+    store = make_store(tmp_path, max_page_bytes=512)
+    _, _, summary = persist(store, [[1, "x" * 1000]])
+
+    page = store.read_page(summary["result_id"], offset=0, limit=1)
+
+    assert "rows" not in page
+    assert "next_offset" not in page
+    assert "has_more" not in page
+    assert page["chunk_required"] is True
+    assert page["reason"] == "row_exceeds_page_byte_limit"
+    assert page["row_index"] == 0
+    assert page["total_row_count"] == 1
+    assert page["truncated"] is False
+    assert len(serialize_json(page).encode("utf-8")) <= 512
+
+
+def test_oversized_columns_return_a_bounded_chunk_descriptor(tmp_path):
+    store = make_store(tmp_path, max_page_bytes=512)
+    envelope = build_result(["c" * 1000], [[1]])
+    payload = serialize_json(envelope).encode("utf-8")
+    summary = store.store(envelope, payload)
+
+    page = store.read_page(summary["result_id"], offset=0, limit=1)
+
+    assert page["chunk_required"] is True
+    assert page["reason"] == "columns_exceed_page_byte_limit"
+    assert "next_offset" not in page
+    assert "has_more" not in page
+    assert "columns" not in page
+    assert "row_index" not in page
+    assert page["total_row_count"] == 1
+    assert page["truncated"] is False
+    assert len(serialize_json(page).encode("utf-8")) <= 512
+
+
+def test_page_source_limit_hands_off_before_loading_the_envelope(tmp_path):
+    store = make_store(
+        tmp_path,
+        max_page_bytes=512,
+        max_page_source_bytes=64,
+    )
+    _, payload, summary = persist(store, [[1, "x" * 1000]])
+    assert len(payload) > 64
+
+    with patch.object(
+        store,
+        "_load_envelope",
+        side_effect=AssertionError("oversized source must not be loaded"),
+    ):
+        descriptor = store.read_page(summary["result_id"], offset=0, limit=1)
+
+    assert descriptor == {
+        "result_id": summary["result_id"],
+        "offset": 0,
+        "returned_rows": 0,
+        "chunk_required": True,
+        "reason": "result_exceeds_page_source_limit",
+        "source_bytes": len(payload),
+        "max_page_source_bytes": 64,
+    }
+    assert "total_row_count" not in descriptor
+    assert "truncated" not in descriptor
+    assert "next_offset" not in descriptor
+    assert "has_more" not in descriptor
+    assert len(serialize_json(descriptor).encode("utf-8")) <= 512
+
+
+def test_zero_disables_the_page_source_limit(tmp_path):
+    store = make_store(
+        tmp_path,
+        max_page_bytes=0,
+        max_page_source_bytes=0,
+    )
+    row = [1, "x" * 1000]
+    _, _, summary = persist(store, [row])
+
+    page = store.read_page(summary["result_id"], offset=0, limit=1)
+
+    assert page["rows"] == [row]
+    assert "chunk_required" not in page
+
+
+def test_page_size_accounting_is_exact_for_unicode_rows(tmp_path):
+    uncapped_store = make_store(tmp_path, max_page_bytes=0)
+    rows = [[index, "中文\r\n" * 40] for index in range(3)]
+    _, _, summary = persist(uncapped_store, rows)
+    full_page = uncapped_store.read_page(summary["result_id"], offset=0, limit=3)
+    exact_size = len(serialize_json(full_page).encode("utf-8"))
+    assert exact_size >= 512
+
+    exact_store = make_store(tmp_path, max_page_bytes=exact_size)
+    exact_page = exact_store.read_page(summary["result_id"], offset=0, limit=3)
+    assert exact_page["rows"] == rows
+    assert len(serialize_json(exact_page).encode("utf-8")) == exact_size
+
+    smaller_store = make_store(tmp_path, max_page_bytes=exact_size - 1)
+    smaller_page = smaller_store.read_page(summary["result_id"], offset=0, limit=3)
+    assert smaller_page["returned_rows"] == 2
+    assert len(serialize_json(smaller_page).encode("utf-8")) <= exact_size - 1
+
+
+def test_page_selection_serializes_each_candidate_row_once(tmp_path):
+    store = make_store(tmp_path, max_page_bytes=512)
+    _, _, summary = persist(store, [[index, "x" * 180] for index in range(5)])
+    original_serialize_json = serialize_json
+    row_calls = []
+
+    def track_row_serialization(value):
+        if isinstance(value, list) and len(value) == 2 and isinstance(value[0], int):
+            row_calls.append(value[0])
+        return original_serialize_json(value)
+
+    with patch(
+        "mssql_mcp_server.result_store.serialize_json",
+        side_effect=track_row_serialization,
+    ):
+        page = store.read_page(summary["result_id"], offset=0, limit=5)
+
+    assert page["returned_rows"] == 1
+    assert row_calls == [0, 1]
+
+
+def test_zero_page_cap_returns_an_oversized_row_inline(tmp_path):
+    store = make_store(tmp_path, max_page_bytes=0)
+    row = [1, "x" * 1000]
+    _, _, summary = persist(store, [row])
+
+    page = store.read_page(summary["result_id"], offset=0, limit=1)
+
+    assert page["rows"] == [row]
+    assert "chunk_required" not in page
+
+
+def test_chunk_pagination_reconstructs_full_json(tmp_path):
+    store = make_store(tmp_path, max_chunk_bytes=13)
+    _, payload, summary = persist(store, [[1, "中文"], [2, None]])
+    chunks = []
+    offset = 0
+
+    while True:
+        chunk = store.read_chunk(
+            summary["result_id"], offset_bytes=offset, max_bytes=13
+        )
+        chunks.append(base64.b64decode(chunk["data_base64"]))
+        assert "sha256" not in chunk
+        offset = chunk["next_offset"]
+        if chunk["eof"]:
+            break
+
+    assert b"".join(chunks) == payload
+    assert summary["sha256"] == hashlib.sha256(payload).hexdigest()
+
+
+def test_chunk_reader_does_not_load_the_complete_payload(tmp_path):
+    store = make_store(tmp_path, max_chunk_bytes=16)
+    _, payload, summary = persist(store, [[1, "x" * 10_000]])
+
+    with patch.object(
+        store, "_read_payload", side_effect=AssertionError("full read is forbidden")
+    ):
+        chunk = store.read_chunk(summary["result_id"], offset_bytes=100, max_bytes=16)
+
+    assert base64.b64decode(chunk["data_base64"]) == payload[100:116]
+    assert chunk["returned_bytes"] == 16
+
+
+def test_chunk_offset_boundaries(tmp_path):
+    store = make_store(tmp_path)
+    _, payload, summary = persist(store, [[1, "value"]])
+
+    eof = store.read_chunk(summary["result_id"], offset_bytes=len(payload), max_bytes=1)
+    assert eof["returned_bytes"] == 0
+    assert eof["next_offset"] == len(payload)
+    assert eof["eof"] is True
+
+    with pytest.raises(ValueError, match="offset_bytes must not exceed"):
+        store.read_chunk(
+            summary["result_id"], offset_bytes=len(payload) + 1, max_bytes=1
+        )
+
+
+def test_page_offset_boundaries(tmp_path):
+    store = make_store(tmp_path)
+    _, _, summary = persist(store, [[1, "value"]])
+
+    terminal = store.read_page(summary["result_id"], offset=1, limit=1)
+    assert terminal["rows"] == []
+    assert terminal["returned_rows"] == 0
+    assert terminal["next_offset"] == 1
+    assert terminal["has_more"] is False
+
+    with pytest.raises(ValueError, match="offset must not exceed"):
+        store.read_page(summary["result_id"], offset=2, limit=1)
+
+
+@pytest.mark.parametrize(
+    "result_id",
+    ["../secret", "A" * 32, "0" * 31, "0" * 33, "C:\\secret"],
+)
+def test_result_id_rejects_traversal_and_noncanonical_values(tmp_path, result_id):
+    store = make_store(tmp_path)
+
+    with pytest.raises(ValueError, match="result_id"):
+        store.read_page(result_id)
+
+
+@pytest.mark.parametrize(
+    ("offset", "limit"),
+    [(-1, 1), (0, 0), (0, -1), (True, 1), (0, True), (0, 11)],
+)
+def test_page_argument_validation(tmp_path, offset, limit):
+    store = make_store(tmp_path)
+    _, _, summary = persist(store, [[1, "value"]])
+
+    with pytest.raises(ValueError):
+        store.read_page(summary["result_id"], offset=offset, limit=limit)
+
+
+def test_expired_results_cannot_be_read(tmp_path):
+    store = make_store(tmp_path, ttl_seconds=1)
+    _, _, summary = persist(store, [[1, "value"]])
+    result_path = Path(summary["result_path"])
+    old_time = time.time() - 10
+    os.utime(result_path, (old_time, old_time))
+
+    with pytest.raises(FileNotFoundError, match="expired"):
+        store.read_page(summary["result_id"])
+
+
+def test_corrupt_result_is_rejected_by_row_reader(tmp_path):
+    store = make_store(tmp_path)
+    _, _, summary = persist(store, [[1, "value"]])
+    Path(summary["result_path"]).write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="corrupt"):
+        store.read_page(summary["result_id"])
+
+
+def test_failed_atomic_replace_does_not_leave_partial_result(tmp_path):
+    store = make_store(tmp_path)
+    envelope = build_result(["id"], [[1]])
+    payload = serialize_json(envelope).encode("utf-8")
+
+    with (
+        patch("os.replace", side_effect=OSError("replace failed")),
+        pytest.raises(OSError, match="replace failed"),
+    ):
+        store.store(envelope, payload)
+
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -25,6 +25,7 @@ def make_store(tmp_path: Path, **overrides) -> ResultStore:
         "max_page_source_bytes": 64 * 1024 * 1024,
         "max_chunk_bytes": 16,
         "ttl_seconds": 3600,
+        "max_file_bytes": 1024 * 1024,
         "max_store_bytes": 1024 * 1024,
     }
     defaults.update(overrides)
@@ -35,6 +36,10 @@ def persist(store: ResultStore, rows):
     envelope = build_result(["id", "value"], rows)
     payload = serialize_json(envelope).encode("utf-8")
     return envelope, payload, store.store(envelope, payload)
+
+
+def stored_path(result_dir: Path, summary: dict) -> Path:
+    return result_dir / f'{summary["result_id"]}.json'
 
 
 def test_storage_is_disabled_without_an_output_directory():
@@ -89,6 +94,25 @@ def test_zero_page_source_limit_is_preserved_from_env(tmp_path, monkeypatch):
     assert ResultStoreConfig.from_env().max_page_source_bytes == 0
 
 
+def test_file_limit_and_path_policy_are_loaded_from_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setenv("MSSQL_RESULT_MAX_FILE_BYTES", "1234")
+    monkeypatch.setenv("MSSQL_RESULT_INCLUDE_PATH", "true")
+
+    config = ResultStoreConfig.from_env()
+
+    assert config.max_file_bytes == 1234
+    assert config.include_path is True
+
+
+def test_invalid_include_path_value_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("MSSQL_RESULT_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setenv("MSSQL_RESULT_INCLUDE_PATH", "yes")
+
+    with pytest.raises(ValueError, match="MSSQL_RESULT_INCLUDE_PATH"):
+        ResultStoreConfig.from_env()
+
+
 @pytest.mark.parametrize(
     ("row_count", "payload_size", "expected"),
     [
@@ -110,7 +134,7 @@ def test_stored_file_is_canonical_json_and_summary_is_bounded(tmp_path):
     rows = [[1, "Region, Segment"], [2, "中文\r\n多行"], [3, None]]
     envelope, payload, summary = persist(store, rows)
 
-    result_path = Path(summary["result_path"])
+    result_path = stored_path(tmp_path, summary)
     assert result_path.parent == tmp_path.resolve()
     assert result_path.read_bytes() == payload
     assert json.loads(payload) == envelope
@@ -123,6 +147,68 @@ def test_stored_file_is_canonical_json_and_summary_is_bounded(tmp_path):
     assert summary["truncated"] is False
     assert summary["expires_at"] is not None
     assert "rows" not in summary
+    assert "result_path" not in summary
+
+
+def test_result_path_is_returned_only_when_explicitly_enabled(tmp_path):
+    store = make_store(tmp_path, include_path=True)
+
+    _, _, summary = persist(store, [[1, "value"]])
+
+    assert summary["result_path"] == str(stored_path(tmp_path, summary))
+
+
+def test_single_result_limit_is_independent_from_store_quota(tmp_path):
+    envelope = build_result(["value"], [["x" * 100]])
+    payload = serialize_json(envelope).encode("utf-8")
+    store = make_store(
+        tmp_path,
+        max_file_bytes=len(payload) - 1,
+        max_store_bytes=len(payload) * 2,
+    )
+
+    with pytest.raises(ValueError, match="MSSQL_RESULT_MAX_FILE_BYTES"):
+        store.store(envelope, payload)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_store_quota_evicts_oldest_result(tmp_path):
+    first = build_result(["value"], [["first"]])
+    second = build_result(["value"], [["second"]])
+    first_payload = serialize_json(first).encode("utf-8")
+    second_payload = serialize_json(second).encode("utf-8")
+    store = make_store(
+        tmp_path,
+        max_file_bytes=0,
+        max_store_bytes=len(first_payload) + len(second_payload) - 1,
+    )
+    first_summary = store.store(first, first_payload)
+    first_path = stored_path(tmp_path, first_summary)
+    os.utime(first_path, (time.time() - 10, time.time() - 10))
+
+    second_summary = store.store(second, second_payload)
+
+    assert not first_path.exists()
+    assert stored_path(tmp_path, second_summary).exists()
+
+
+def test_result_larger_than_store_quota_is_rejected_without_eviction(tmp_path):
+    existing = build_result(["value"], [["kept"]])
+    existing_payload = serialize_json(existing).encode("utf-8")
+    oversized = build_result(["value"], [["x" * 100]])
+    oversized_payload = serialize_json(oversized).encode("utf-8")
+    store = make_store(
+        tmp_path,
+        max_file_bytes=0,
+        max_store_bytes=len(existing_payload),
+    )
+    existing_summary = store.store(existing, existing_payload)
+
+    with pytest.raises(ValueError, match="MSSQL_RESULT_MAX_STORE_BYTES"):
+        store.store(oversized, oversized_payload)
+
+    assert stored_path(tmp_path, existing_summary).exists()
 
 
 def test_large_single_cell_is_not_leaked_in_preview(tmp_path):
@@ -384,7 +470,7 @@ def test_page_argument_validation(tmp_path, offset, limit):
 def test_expired_results_cannot_be_read(tmp_path):
     store = make_store(tmp_path, ttl_seconds=1)
     _, _, summary = persist(store, [[1, "value"]])
-    result_path = Path(summary["result_path"])
+    result_path = stored_path(tmp_path, summary)
     old_time = time.time() - 10
     os.utime(result_path, (old_time, old_time))
 
@@ -395,7 +481,7 @@ def test_expired_results_cannot_be_read(tmp_path):
 def test_corrupt_result_is_rejected_by_row_reader(tmp_path):
     store = make_store(tmp_path)
     _, _, summary = persist(store, [[1, "value"]])
-    Path(summary["result_path"]).write_text("not-json", encoding="utf-8")
+    stored_path(tmp_path, summary).write_text("not-json", encoding="utf-8")
 
     with pytest.raises(RuntimeError, match="corrupt"):
         store.read_page(summary["result_id"])

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,9 +1,10 @@
 """Security tests for SQL injection prevention and safe query handling."""
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
-from mssql_mcp_server.server import validate_table_name, read_resource, call_tool
 from pydantic import AnyUrl
-from mcp.types import TextContent
+
+from mssql_mcp_server.server import call_tool, read_resource
 
 
 class TestSQLInjectionPrevention:
@@ -41,18 +42,19 @@ class TestSQLInjectionPrevention:
                 'MSSQL_USER': 'test',
                 'MSSQL_PASSWORD': 'test',
                 'MSSQL_DATABASE': 'test'
-            }):
+            }, clear=True):
                 # Test safe table read
                 uri = AnyUrl("mssql://users/data")
                 mock_cursor.description = [('id',), ('name',)]
                 mock_cursor.fetchall.return_value = [(1, 'John'), (2, 'Jane')]
-                
-                result = await read_resource(uri)
-                
+
+                content = await read_resource(uri)
+
                 # Verify the query was escaped properly
                 executed_query = mock_cursor.execute.call_args[0][0]
                 assert '[users]' in executed_query
                 assert 'SELECT TOP 100 * FROM [users]' == executed_query
+                assert content == 'id,name\n1,John\n2,Jane'
     
     def test_parameterized_queries(self):
         """Ensure queries use parameters where user input is involved."""
@@ -60,7 +62,6 @@ class TestSQLInjectionPrevention:
         # The current implementation doesn't use parameterized queries for table names
         # because table names can't be parameterized in SQL
         # Instead, we validate and escape them
-        pass
     
     @pytest.mark.asyncio
     async def test_query_result_sanitization(self):
@@ -78,14 +79,12 @@ class TestSQLInjectionPrevention:
                 # Test that passwords or sensitive data aren't exposed in errors
                 mock_cursor.execute.side_effect = Exception("Login failed for user 'sa' with password 'secret123'")
                 
-                result = await call_tool("execute_sql", {"query": "SELECT * FROM users"})
-                
+                with pytest.raises(RuntimeError) as exc_info:
+                    await call_tool("execute_sql", {"query": "SELECT * FROM users"})
+
                 # Verify sensitive info is not in the error message
-                assert isinstance(result, list)
-                assert len(result) == 1
-                assert isinstance(result[0], TextContent)
-                assert 'secret123' not in result[0].text
-                assert 'Error executing query' in result[0].text
+                assert 'secret123' not in str(exc_info.value)
+                assert 'Error executing query' in str(exc_info.value)
 
 
 class TestInputValidation:
@@ -155,7 +154,6 @@ class TestResourceAccessControl:
                 
                 # Verify system tables are filtered out (if implemented)
                 # Currently the query uses INFORMATION_SCHEMA which should only return user tables
-                resource_names = [r.name for r in resources]
                 assert len(resources) == 4  # All tables are returned currently
     
     @pytest.mark.asyncio 
@@ -182,7 +180,5 @@ class TestResourceAccessControl:
                     # The queries will be executed (current implementation doesn't block them)
                     # but we ensure errors are handled gracefully
                     mock_cursor.execute.side_effect = Exception("Permission denied")
-                    result = await call_tool("execute_sql", {"query": query})
-                    
-                    assert len(result) == 1
-                    assert "Error executing query" in result[0].text
+                    with pytest.raises(RuntimeError, match="Permission denied"):
+                        await call_tool("execute_sql", {"query": query})

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,117 @@
+import csv
+import json
+from datetime import UTC, date, datetime, time
+from decimal import Decimal
+from io import StringIO
+from uuid import UUID
+
+import pytest
+
+from mssql_mcp_server.serialization import (
+    ResultFormat,
+    build_result,
+    normalize_value,
+    serialize_result,
+)
+
+
+def test_json_preserves_delimiters_multiline_unicode_and_null():
+    text = serialize_result(
+        ["key_columns", "definition", "empty", "nullable"],
+        [["Region, Segment", 'SELECT "quoted"\r\nFROM 表格\t欄', "", None]],
+        ResultFormat.JSON,
+    )
+
+    parsed = json.loads(text)
+
+    assert parsed == {
+        "columns": ["key_columns", "definition", "empty", "nullable"],
+        "rows": [["Region, Segment", 'SELECT "quoted"\r\nFROM 表格\t欄', "", None]],
+        "row_count": 1,
+        "truncated": False,
+    }
+    assert "表格" in text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (Decimal("123.4500"), "123.4500"),
+        (date(2026, 7, 28), "2026-07-28"),
+        (time(13, 14, 15, 123456), "13:14:15.123456"),
+        (
+            datetime(2026, 7, 28, 13, 14, 15, tzinfo=UTC),
+            "2026-07-28T13:14:15+00:00",
+        ),
+        (
+            UUID("12345678-1234-5678-1234-567812345678"),
+            "12345678-1234-5678-1234-567812345678",
+        ),
+        (b"\x00\xff", "base64:AP8="),
+        (memoryview(b"abc"), "base64:YWJj"),
+    ],
+)
+def test_normalize_non_native_json_types(value, expected):
+    assert normalize_value(value) == expected
+
+
+@pytest.mark.parametrize("rows", [[], [[1]], [[1], [2], [3]]])
+def test_result_envelope_counts_zero_one_and_many_rows(rows):
+    result = build_result(["id"], rows)
+
+    assert result["rows"] == rows
+    assert result["row_count"] == len(rows)
+    assert result["truncated"] is False
+
+
+def test_native_numbers_and_booleans_remain_typed():
+    result = build_result(["integer", "float", "boolean"], [[10, 1.25, True]])
+
+    assert result["rows"] == [[10, 1.25, True]]
+
+
+def test_non_finite_floats_use_stable_json_strings():
+    text = serialize_result(
+        ["value"], [[float("nan")], [float("inf")]], ResultFormat.JSON
+    )
+
+    assert json.loads(text)["rows"] == [["nan"], ["inf"]]
+
+
+def test_csv_compatibility_mode_uses_legal_quoting():
+    text = serialize_result(
+        ["key_columns", "definition", "nullable"],
+        [["Region, Segment", 'SELECT "x"\nFROM t', None]],
+        ResultFormat.CSV,
+    )
+
+    parsed = list(csv.reader(StringIO(text)))
+
+    assert parsed == [
+        ["key_columns", "definition", "nullable"],
+        ["Region, Segment", 'SELECT "x"\nFROM t', ""],
+    ]
+
+
+def test_legacy_mode_reproduces_original_unsafe_delimiter_output():
+    text = serialize_result(
+        ["key_columns", "nullable"],
+        [["Region, Segment", None]],
+        ResultFormat.LEGACY,
+    )
+
+    assert text == "key_columns,nullable\nRegion, Segment,None"
+
+    binary_text = serialize_result(["binary"], [[b"abc"]], ResultFormat.LEGACY)
+    assert binary_text == "binary\nb'abc'"
+
+
+def test_result_format_parser_defaults_to_legacy_and_validates_values():
+    assert ResultFormat.parse(None) is ResultFormat.LEGACY
+    assert ResultFormat.parse(" CSV ") is ResultFormat.CSV
+
+    with pytest.raises(ValueError, match="Unsupported result format"):
+        ResultFormat.parse("yaml")
+
+    with pytest.raises(ValueError, match="Unsupported result format"):
+        ResultFormat.parse("")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,12 @@
 import pytest
-from mssql_mcp_server.server import app, list_tools, list_resources, read_resource, call_tool
-from pydantic import AnyUrl
+
+from mssql_mcp_server.server import (
+    app,
+    call_tool,
+    list_resources,
+    list_tools,
+)
+
 
 def test_server_initialization():
     """Test that the server initializes correctly."""


### PR DESCRIPTION
## Why

The existing query output joins columns and values with commas and newlines without escaping them.

This becomes ambiguous when database values contain commas, quotes, line breaks, SQL definitions, or user-provided text. MCP clients and language models may no longer be able to reliably distinguish columns, rows, and original values.

Large result sets are also returned inline in a single MCP response, which can consume a significant portion of the model context before the result can be inspected or filtered.

## Summary

This PR adds safer and more predictable SQL result handling:

- Adds opt-in JSON and properly quoted CSV output.
- Keeps the existing legacy format as the default for backward compatibility.
- Adds opt-in file-backed storage for oversized results.
- Returns compact metadata and bounded preview rows instead of the full stored payload.
- Provides bounded row pagination and byte-range chunk retrieval.
- Adds configurable limits for inline responses, stored files, total storage, expiry, previews, and path exposure.
- Adds an export CLI and a context-size benchmark.
- Expands tests for serialization, compatibility, storage, retrieval, validation, and security.

## New options

### Environment variables

| Option | Purpose |
| --- | --- |
| `MSSQL_RESULT_FORMAT` | Selects `legacy`, `json`, or `csv` output. |
| `MSSQL_RESULT_OUTPUT_DIR` | Enables file-backed storage in the specified absolute directory. |
| `MSSQL_RESULT_MAX_INLINE_ROWS` | Stores results exceeding the inline row limit. |
| `MSSQL_RESULT_MAX_INLINE_BYTES` | Stores results exceeding the inline byte limit. |
| `MSSQL_RESULT_PREVIEW_ROWS` | Limits preview rows in a stored-result summary. |
| `MSSQL_RESULT_PREVIEW_BYTES` | Limits the serialized preview size. |
| `MSSQL_RESULT_DEFAULT_PAGE_ROWS` | Sets the default stored-result page size. |
| `MSSQL_RESULT_MAX_PAGE_ROWS` | Limits rows requested in one page. |
| `MSSQL_RESULT_MAX_PAGE_BYTES` | Limits the serialized size of one page. |
| `MSSQL_RESULT_MAX_PAGE_SOURCE_BYTES` | Prevents large stored files from being fully parsed for pagination. |
| `MSSQL_RESULT_MAX_CHUNK_BYTES` | Limits bytes returned by one chunk read. |
| `MSSQL_RESULT_TTL_SECONDS` | Sets how long stored results remain accessible. |
| `MSSQL_RESULT_MAX_FILE_BYTES` | Limits the size of one stored result. |
| `MSSQL_RESULT_MAX_STORE_BYTES` | Limits total storage and evicts older results when needed. |
| `MSSQL_RESULT_INCLUDE_PATH` | Optionally includes the local result path in stored-result metadata. |

### MCP tool arguments

| Option | Purpose |
| --- | --- |
| `result_format` | Overrides the configured format for one `execute_sql` call. |
| `store_result` | Forces one result to be stored even when it is below the thresholds. |
| `offset` / `limit` | Selects a bounded row page through `get_sql_result`. |
| `offset_bytes` / `max_bytes` | Selects a bounded file chunk through `read_sql_result_chunk`. |

Stored results return a server-generated `result_id` by default. This mode works without shared filesystem access and allows MCP clients to retrieve bounded pages or chunks.

When `MSSQL_RESULT_INCLUDE_PATH=true`, the result also includes `result_path`. This is intended for trusted local workflows where another host-side process can read the stored file directly.

### Export CLI

`export-sql-result` exports a complete stored result by `result_id` or validates and exports an existing canonical result file.

## Additional fixes

Result-returning statements are detected using cursor metadata rather than SQL text matching, improving support for CTEs, stored procedures, and statements such as `UPDATE ... OUTPUT`.

Database failures are also reported as MCP errors, with password-like values redacted, and database resources are closed reliably after failures.

## Compatibility

The legacy result format remains the default.

JSON, CSV, and file-backed storage are opt-in. Existing configurations continue to behave as before unless the new settings or tool arguments are used.

## Limitation

Query results are still fetched and serialized fully in server memory before the storage decision.

This change bounds MCP responses and prevents oversized payloads from entering the model context, but it does not provide streaming query processing.

## Validation

```bash
python run_tests.py --suite all
```
